### PR TITLE
Align stream list metadata layout

### DIFF
--- a/frontend/src/components/StreamSidebar.react.tsx
+++ b/frontend/src/components/StreamSidebar.react.tsx
@@ -351,37 +351,55 @@ const StreamSidebar = ({
               className={`stream-sidebar__item ${item.isActive ? "stream-sidebar__item--active" : ""}`}
               aria-current={item.isActive ? "page" : undefined}
             >
-              <div
-                className={`stream-status-dot ${item.statusClass}`}
-                aria-hidden="true"
-              />
-              <div className="stream-sidebar__item-main">
-                <div className="stream-sidebar__item-header">
-                  <div className="stream-sidebar__item-heading">
-                    <span className="stream-sidebar__item-title">
-                      {item.title}
-                    </span>
-                    {item.isPager ? (
-                      <span className="badge rounded-pill text-bg-info-subtle text-info-emphasis">
-                        Pager
-                      </span>
-                    ) : null}
-                  </div>
-                  <span className="stream-sidebar__item-time">
-                    {item.previewTime}
-                  </span>
-                </div>
-                <div className="stream-sidebar__item-preview text-body-secondary">
-                  {item.previewText}
-                </div>
-              </div>
-              {item.unreadCount > 0 ? (
-                <Badge
-                  aria-label={`${item.unreadCount} new messages`}
-                  value={item.unreadCount}
-                  max={99}
+              <Flex align="start" gap={3} className="stream-sidebar__item-layout">
+                <div
+                  className={`stream-status-dot ${item.statusClass}`}
+                  aria-hidden="true"
                 />
-              ) : null}
+                <Flex
+                  className="stream-sidebar__item-main"
+                  justify="between"
+                  align="start"
+                  gap={3}
+                >
+                  <Flex
+                    direction="column"
+                    gap={2}
+                    className="stream-sidebar__item-content"
+                  >
+                    <Flex align="center" gap={2} className="stream-sidebar__item-heading">
+                      <span className="stream-sidebar__item-title">
+                        {item.title}
+                      </span>
+                      {item.isPager ? (
+                        <span className="badge rounded-pill text-bg-info-subtle text-info-emphasis">
+                          Pager
+                        </span>
+                      ) : null}
+                    </Flex>
+                    <div className="stream-sidebar__item-preview text-body-secondary">
+                      {item.previewText}
+                    </div>
+                  </Flex>
+                  <Flex
+                    direction="column"
+                    align="end"
+                    gap={1}
+                    className="stream-sidebar__item-meta"
+                  >
+                    <span className="stream-sidebar__item-time">
+                      {item.previewTime}
+                    </span>
+                    {item.unreadCount > 0 ? (
+                      <Badge
+                        aria-label={`${item.unreadCount} new messages`}
+                        value={item.unreadCount}
+                        max={99}
+                      />
+                    ) : null}
+                  </Flex>
+                </Flex>
+              </Flex>
             </Button>
           ))}
         </div>

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -723,9 +723,6 @@ a:hover {
   color: inherit;
   padding: 0.75rem;
   border-radius: 0.85rem;
-  display: flex;
-  align-items: flex-start;
-  gap: 0.75rem;
   width: 100%;
   text-align: left;
   transition: background-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
@@ -760,18 +757,7 @@ a:hover {
   min-width: 0;
 }
 
-.stream-sidebar__item-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.5rem;
-  margin-bottom: 0.35rem;
-}
-
 .stream-sidebar__item-heading {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
   min-width: 0;
   flex: 1;
 }
@@ -800,6 +786,23 @@ a:hover {
   white-space: normal;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.stream-sidebar__item-layout {
+  width: 100%;
+}
+
+.stream-sidebar__item-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.stream-sidebar__item-meta {
+  text-align: right;
+}
+
+.stream-sidebar__item-meta .app-badge {
+  align-self: flex-end;
 }
 
 .app-badge {


### PR DESCRIPTION
## Summary
- reorganize stream sidebar list items to use the Flex primitive and stack metadata cleanly
- update styling so the timestamp stays visible above the unread badge when present

## Testing
- npm run lint

![Stream sidebar layout](browser:/invocations/sqctvanr/artifacts/artifacts/stream-sidebar.png)

------
https://chatgpt.com/codex/tasks/task_e_68d33fc48aa48327aeb284412a2ea64b