### PR TITLE
Group pager incident updates with structured metadata

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -33,6 +33,9 @@ transcribing multiple radio or pager feeds in real time.
 - Panels that may take time to populate display loading spinners until data arrives so operators understand the UI is still working.
 - Check aggregate counters for transcript volume, confidence, and recent activity.
 - Receive real-time transcript bursts; contiguous speech is grouped for readability.
+- Pager feed messages that share an incident number and arrive within roughly a minute
+  collapse into a single grouped thread, showing parsed incident details like the call
+  type, location, and alarm level alongside the individual updates.
 - When Whisper returns no text but audio passes silence thresholds, show a "Silence" entry with playback controls.
 - Load roughly the last three hours of transcripts per stream on initial view and fetch older history on demand (including auto-loading when needed) to keep the interface responsive. Loaded transcripts persist until refresh or reset; the toolbar no longer clears local history.
 - When a browser tab stays hidden for about fifteen minutes, the UI releases its WebSocket connection and reconnects automatically (refreshing stream data) as soon as the operator returns to the tab.

--- a/backend/src/wavecap_backend/models.py
+++ b/backend/src/wavecap_backend/models.py
@@ -87,6 +87,40 @@ class TranscriptionAlertTrigger(APIModel):
     notify: Optional[bool] = None
 
 
+class PagerIncidentDetails(APIModel):
+    incidentId: Optional[str] = Field(default=None, alias="incidentId")
+    callType: Optional[str] = Field(default=None, alias="callType")
+    address: Optional[str] = None
+    alarmLevel: Optional[str] = Field(default=None, alias="alarmLevel")
+    map: Optional[str] = None
+    talkgroup: Optional[str] = None
+    narrative: Optional[str] = None
+    units: Optional[str] = None
+    rawMessage: Optional[str] = Field(default=None, alias="rawMessage")
+
+    @field_validator(
+        "incidentId",
+        "callType",
+        "address",
+        "alarmLevel",
+        "map",
+        "talkgroup",
+        "narrative",
+        "units",
+        "rawMessage",
+        mode="before",
+    )
+    @classmethod
+    def _normalise_optional_text(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            cleaned = value.strip()
+        else:
+            cleaned = str(value).strip()
+        return cleaned or None
+
+
 class TranscriptionResult(APIModel):
     id: str
     streamId: str = Field(alias="streamId")
@@ -109,6 +143,9 @@ class TranscriptionResult(APIModel):
     reviewedAt: Optional[datetime] = Field(default=None, alias="reviewedAt")
     reviewedBy: Optional[str] = Field(default=None, alias="reviewedBy")
     alerts: Optional[List[TranscriptionAlertTrigger]] = None
+    pagerIncident: Optional["PagerIncidentDetails"] = Field(
+        default=None, alias="pagerIncident"
+    )
 
     @field_validator("timestamp", mode="before")
     @classmethod
@@ -424,6 +461,7 @@ class PagerWebhookRequest(APIModel):
     priority: Optional[str] = None
     timestamp: Optional[datetime] = None
     details: Optional[List[str]] = None
+    incident: Optional["PagerIncidentDetails"] = None
 
     @field_validator("timestamp", mode="before")
     @classmethod

--- a/backend/src/wavecap_backend/stream_manager.py
+++ b/backend/src/wavecap_backend/stream_manager.py
@@ -823,6 +823,8 @@ class StreamManager:
             duration=None,
             segments=None,
         )
+        if request.incident:
+            transcription.pagerIncident = request.incident
         alerts = self.alert_evaluator.evaluate(text)
         if alerts:
             transcription.alerts = alerts

--- a/backend/tests/test_server.py
+++ b/backend/tests/test_server.py
@@ -129,6 +129,7 @@ def test_pager_webhook_endpoint(patched_app: TestClient):
     body = response.json()
     assert body["status"] == "accepted"
     assert body["transcription"]["text"].startswith("Dispatch")
+    assert body["transcription"]["pagerIncident"] is None
 
     unauthorized = client.post(
         f"/api/pager-feeds/{stream_id}?token=wrong-token",
@@ -189,6 +190,13 @@ def test_pager_webhook_known_format(patched_app: TestClient):
     assert "Alarm level 1" in text
     assert "Map: ADL 178 B2" in text
     assert body["transcription"]["timestamp"] == "2025-09-01T10:35:54Z"
+    incident = body["transcription"]["pagerIncident"]
+    assert incident["incidentId"] == "INC0123"
+    assert incident["callType"] == "TRAINING/TEST ONLY"
+    assert incident["address"] == "CFS - HAPPY VALLEY 1 GLORY CT HAPPY VALLEY"
+    assert incident["alarmLevel"] == "1"
+    assert incident["map"] == "ADL 178 B2"
+    assert incident["talkgroup"] == "134"
 
 
 def test_export_reviewed_zip(patched_app: TestClient):

--- a/frontend/src/components/StreamTranscriptionPanel.react.tsx
+++ b/frontend/src/components/StreamTranscriptionPanel.react.tsx
@@ -1810,6 +1810,34 @@ export const StreamTranscriptionPanel = ({
     groups.map((group) => {
       const renderedRecordings = new Set<string>();
       const audioElements: JSX.Element[] = [];
+      const incidentSource = group.transcriptions.find(
+        (item) => item.pagerIncident?.incidentId,
+      );
+      const incidentDetails = incidentSource?.pagerIncident ?? null;
+      const incidentIdLabel = (() => {
+        const value =
+          incidentDetails?.incidentId ?? group.pagerIncidentId ?? null;
+        if (typeof value !== "string") {
+          return null;
+        }
+        const trimmed = value.trim();
+        return trimmed.length > 0 ? trimmed : null;
+      })();
+      const incidentCallType = incidentDetails?.callType ?? null;
+      const incidentMetaParts: string[] = [];
+      if (incidentDetails?.address) {
+        incidentMetaParts.push(incidentDetails.address);
+      }
+      if (incidentDetails?.alarmLevel) {
+        incidentMetaParts.push(`Alarm level ${incidentDetails.alarmLevel}`);
+      }
+      if (incidentDetails?.talkgroup) {
+        incidentMetaParts.push(`Talkgroup ${incidentDetails.talkgroup}`);
+      }
+      if (incidentDetails?.map) {
+        incidentMetaParts.push(`Map ${incidentDetails.map}`);
+      }
+      const incidentNarrative = incidentDetails?.narrative ?? null;
 
       const transcriptionItems = group.transcriptions.flatMap(
         (transcription) => {
@@ -2165,6 +2193,36 @@ export const StreamTranscriptionPanel = ({
                 </span>
               ) : null}
             </header>
+            {incidentIdLabel || incidentCallType || incidentMetaParts.length > 0 || incidentNarrative ? (
+              <div className="transcript-thread__incident-summary">
+                {incidentIdLabel || incidentCallType ? (
+                  <div className="transcript-thread__incident">
+                    {incidentIdLabel ? (
+                      <span className="transcript-thread__incident-id">
+                        {incidentIdLabel}
+                      </span>
+                    ) : null}
+                    {incidentCallType ? (
+                      <span className="transcript-thread__incident-type">
+                        {incidentCallType}
+                      </span>
+                    ) : null}
+                  </div>
+                ) : null}
+                {incidentMetaParts.length > 0 ? (
+                  <div className="transcript-thread__incident-meta">
+                    {incidentMetaParts.map((part, index) => (
+                      <span key={`${group.id}-incident-meta-${index}`}>{part}</span>
+                    ))}
+                  </div>
+                ) : null}
+                {incidentNarrative ? (
+                  <div className="transcript-thread__incident-narrative">
+                    {incidentNarrative}
+                  </div>
+                ) : null}
+              </div>
+            ) : null}
             <div className="transcript-thread__content">{groupContent}</div>
             {audioElements}
           </div>

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -1711,6 +1711,44 @@ a:hover {
   color: rgb(var(--app-ink-subtle-rgb));
 }
 
+.transcript-thread__incident-summary {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.8rem;
+}
+
+.transcript-thread__incident {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.5rem;
+  font-weight: 600;
+  color: rgb(var(--app-insight-strong-rgb));
+}
+
+.transcript-thread__incident-id {
+  letter-spacing: 0.02em;
+}
+
+.transcript-thread__incident-type {
+  color: rgb(var(--app-ink-rgb));
+  font-weight: 600;
+}
+
+.transcript-thread__incident-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  color: rgb(var(--app-ink-subtle-rgb));
+}
+
+.transcript-thread__incident-narrative {
+  color: rgb(var(--app-ink-rgb));
+  font-size: 0.8rem;
+  font-weight: 500;
+}
+
 .transcript-thread__time {
   font-weight: 600;
   color: rgb(var(--app-ink-muted-rgb));

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -41,6 +41,18 @@ export type TranscriptionEventType =
   | "upstream_disconnected"
   | "upstream_reconnected";
 
+export interface PagerIncidentDetails {
+  incidentId?: string | null;
+  callType?: string | null;
+  address?: string | null;
+  alarmLevel?: string | null;
+  map?: string | null;
+  talkgroup?: string | null;
+  narrative?: string | null;
+  units?: string | null;
+  rawMessage?: string | null;
+}
+
 export interface TranscriptionResult {
   id: string;
   streamId: string;
@@ -57,6 +69,7 @@ export interface TranscriptionResult {
   reviewedAt?: IsoDateTimeString | null;
   reviewedBy?: string | null;
   alerts?: TranscriptionAlertTrigger[];
+  pagerIncident?: PagerIncidentDetails | null;
 }
 
 export interface TranscriptionQueryResponse {


### PR DESCRIPTION
## Summary
- parse CFS Flex pager payloads into structured incident metadata and persist it on pager transcriptions
- attach pager incident metadata to webhook ingestion responses and broadcast payloads so clients can consume it
- group pager incident updates on the frontend and surface an incident summary with refreshed styling

## Testing
- PYTHONPATH=src poetry run pytest
- npm run test


------
https://chatgpt.com/codex/tasks/task_e_68d357e33a148327b19c32300ae426cb