### PR TITLE
Fix transcript list auto-scroll initialization

### DIFF
--- a/frontend/src/components/StreamTranscriptList.react.tsx
+++ b/frontend/src/components/StreamTranscriptList.react.tsx
@@ -55,6 +55,7 @@ export const StreamTranscriptList = ({
   });
   const previousFirstEntryRef = useRef<string | null>(null);
   const previousScrollHeightRef = useRef(0);
+  const initialScrollCompletedRef = useRef(false);
 
   const triggerLoadMore = useCallback(() => {
     const callback = loadMoreRef.current;
@@ -86,6 +87,9 @@ export const StreamTranscriptList = ({
       scrollerRef.current = node;
       attachRef(node);
       setScrollContainer(node);
+      if (!node) {
+        initialScrollCompletedRef.current = false;
+      }
     },
     [attachRef],
   );
@@ -100,7 +104,15 @@ export const StreamTranscriptList = ({
     if (!scroller) {
       previousScrollHeightRef.current = 0;
       previousFirstEntryRef.current = null;
+      initialScrollCompletedRef.current = false;
       return;
+    }
+
+    if (orderedTranscriptions.length === 0) {
+      initialScrollCompletedRef.current = false;
+    } else if (!initialScrollCompletedRef.current) {
+      scroller.scrollTop = scroller.scrollHeight;
+      initialScrollCompletedRef.current = true;
     }
 
     const prevFirstKey = previousFirstEntryRef.current;


### PR DESCRIPTION
## Summary
- ensure the stream transcript scroller anchors to the bottom as soon as content renders
- reset the auto-scroll state when the list unmounts or empties so history prefetching only runs when intended

## Testing
- npm run lint
- npm run test
- npm run type-check

## Screenshot
![Combined feed after auto-scroll fix](browser:/invocations/nlksttin/artifacts/artifacts/combined-feed.png)

------
https://chatgpt.com/codex/tasks/task_e_68d37a3153088327a1ec0bafe90d090f