### PR TITLE
Fix transcript feed scroll overflow regression

### DIFF
--- a/frontend/src/App.scss
+++ b/frontend/src/App.scss
@@ -249,6 +249,8 @@
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  flex: 1;
+  min-height: 0;
 }
 
 .conversation-panel__placeholder {


### PR DESCRIPTION
## Summary
- allow the conversation panel body to grow and shrink within the layout so the transcript scroller can overflow correctly

## Testing
- npm run build

## Screenshots
![Transcript view with stable scroll](browser:/invocations/rwqnlypu/artifacts/artifacts/after-fix.png)

------
https://chatgpt.com/codex/tasks/task_e_68d37de0ba9c8327877df983d1afafcc