### PR TITLE
Fix horizontal overflow in stream sidebar list

### DIFF
--- a/frontend/src/components/StreamSidebar.scss
+++ b/frontend/src/components/StreamSidebar.scss
@@ -41,8 +41,23 @@
   flex-direction: column;
   gap: 0.5rem;
   overflow-y: auto;
+  overflow-x: hidden;
   padding-right: 0.25rem;
   min-height: 0;
+}
+
+.stream-sidebar__item-layout {
+  min-width: 0;
+}
+
+.stream-sidebar__item-content {
+  min-width: 0;
+}
+
+.stream-sidebar__item-title,
+.stream-sidebar__item-preview {
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 
 .stream-sidebar__status {


### PR DESCRIPTION
## Summary
- hide horizontal overflow in the stream sidebar list and ensure nested flex layouts can shrink within the drawer
- allow stream titles and previews to wrap so long content no longer forces a horizontal scrollbar

## Testing
- npm run lint

## Screenshots
![Stream sidebar without horizontal scrollbar](browser:/invocations/khujrchv/artifacts/artifacts/stream-sidebar.png)

------
https://chatgpt.com/codex/tasks/task_e_68d38bca5af48327ad8b2fc9208e1319