### PR TITLE
Fix stream sidebar horizontal overflow

### DIFF
--- a/frontend/src/components/StreamSidebar.scss
+++ b/frontend/src/components/StreamSidebar.scss
@@ -43,6 +43,27 @@
   overflow-y: auto;
   padding-right: 0.25rem;
   min-height: 0;
+  min-width: 0;
+  overflow-x: hidden;
+}
+
+.stream-sidebar__item-layout {
+  width: 100%;
+  min-width: 0;
+}
+
+.stream-sidebar__item-content {
+  min-width: 0;
+}
+
+.stream-sidebar__item-title,
+.stream-sidebar__item-preview {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.stream-sidebar__item-preview {
+  min-width: 0;
 }
 
 .stream-sidebar__status {


### PR DESCRIPTION
## Summary
- prevent the stream sidebar list from overflowing horizontally by constraining its width
- allow stream titles and previews to wrap within the available space so long text no longer pushes the layout wider

## Testing
- npm run lint

## Screenshots
![Stream sidebar without horizontal scrollbar](browser:/invocations/fznpiium/artifacts/artifacts/stream-sidebar.png)

------
https://chatgpt.com/codex/tasks/task_e_68d38bca5af48327ad8b2fc9208e1319