### PR TITLE
Adjust stream list styling and restore badge visuals

### DIFF
--- a/frontend/src/components/StreamDirectoryPanel.react.tsx
+++ b/frontend/src/components/StreamDirectoryPanel.react.tsx
@@ -12,6 +12,7 @@ import { Stream, type StreamCommandState } from "@types";
 import Spinner from "./primitives/Spinner.react";
 import Button from "./primitives/Button.react";
 import Flex from "./primitives/Flex.react";
+import "./StreamDirectoryPanel.scss";
 
 interface StreamDirectoryPanelProps {
   streams: Stream[];
@@ -99,7 +100,7 @@ export const StreamDirectoryPanel = ({
   };
 
   return (
-    <section className="card shadow-sm mb-4">
+    <section className="card shadow-sm mb-4 stream-directory">
       <Flex
         className="card-header bg-body-tertiary"
         align="center"
@@ -216,7 +217,7 @@ export const StreamDirectoryPanel = ({
             </p>
           </div>
         ) : (
-          <div className="list-group list-group-flush">
+          <div className="list-group list-group-flush stream-directory__list">
             {streams.map((stream) => {
               const variant = getStatusVariant(stream.status);
               const pendingAction = pendingCommands[stream.id];
@@ -230,22 +231,22 @@ export const StreamDirectoryPanel = ({
               return (
                 <Flex
                   key={stream.id}
-                  className="list-group-item"
+                  className="list-group-item stream-directory__item"
                   direction={{ base: "column", lg: "row" }}
                   align={{ lg: "center" }}
                   justify="between"
-                  gap={3}
+                  gap={2}
                 >
-                  <Flex align="start" gap={3} className="flex-grow-1">
+                  <Flex align="start" gap={2} className="flex-grow-1 stream-directory__item-main">
                     <Radio size={20} className="text-body-tertiary" />
                     <div className="flex-grow-1">
-                      <Flex align="center" gap={2} className="mb-1">
-                        <h3 className="h6 mb-0">{stream.name}</h3>
+                      <Flex align="center" gap={1} className="stream-directory__header">
+                        <h3 className="stream-directory__title">{stream.name}</h3>
                         <span
-                          className={`badge d-inline-flex align-items-center gap-2 ${getStatusBadgeClass(variant)}`}
+                          className={`badge d-inline-flex align-items-center gap-2 stream-directory__status ${getStatusBadgeClass(variant)}`}
                         >
                           {renderStatusIcon(variant)}
-                          <span className="text-capitalize">
+                          <span className="stream-directory__status-label text-capitalize">
                             {stream.status}
                           </span>
                         </span>
@@ -254,12 +255,12 @@ export const StreamDirectoryPanel = ({
                         href={stream.url}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="d-inline-flex align-items-center gap-1 small text-decoration-none link-primary"
+                        className="d-inline-flex align-items-center gap-1 text-decoration-none link-primary stream-directory__link"
                         title={stream.url}
                       >
                         {stream.url}
                       </a>
-                      <div className="small text-body-secondary">
+                      <div className="text-body-secondary stream-directory__meta">
                         {stream.transcriptions?.length || 0} transcriptions
                       </div>
                     </div>

--- a/frontend/src/components/StreamDirectoryPanel.scss
+++ b/frontend/src/components/StreamDirectoryPanel.scss
@@ -1,0 +1,77 @@
+.stream-directory {
+  .stream-directory__list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .stream-directory__item {
+    border: 1px solid rgba(var(--bs-border-color-rgb, 222, 226, 230), 0.7);
+    border-radius: 0.85rem;
+    padding: 0.75rem 0.9rem;
+    background-color: rgba(var(--app-surface-rgb), 0.92);
+  }
+
+  .stream-directory__item + .stream-directory__item {
+    margin-top: 0;
+  }
+
+  .stream-directory__header {
+    margin-bottom: 0.25rem;
+    gap: 0.4rem;
+  }
+
+  .stream-directory__title {
+    margin: 0;
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: rgb(var(--app-ink-rgb));
+    line-height: 1.3;
+  }
+
+  .stream-directory__status {
+    padding: 0.15rem 0.5rem;
+    font-size: 0.65rem;
+    line-height: 1;
+    gap: 0.35rem;
+    border-radius: 999px;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+
+  .stream-directory__status svg {
+    width: 0.75rem;
+    height: 0.75rem;
+  }
+
+  .stream-directory__status-label {
+    font-weight: 600;
+  }
+
+  .stream-directory__link {
+    margin-top: 0.15rem;
+    font-size: 0.8rem;
+    color: rgb(var(--app-ink-subtle-rgb));
+  }
+
+  .stream-directory__link:hover {
+    color: var(--bs-link-hover-color);
+  }
+
+  .stream-directory__meta {
+    margin-top: 0.35rem;
+    font-size: 0.75rem;
+  }
+}
+
+@media (max-width: 991.98px) {
+  .stream-directory {
+    .stream-directory__item {
+      padding: 0.65rem 0.75rem;
+    }
+
+    .stream-directory__item-main {
+      gap: 0.5rem;
+    }
+  }
+}

--- a/frontend/src/components/StreamSidebar.scss
+++ b/frontend/src/components/StreamSidebar.scss
@@ -53,6 +53,7 @@
 }
 
 .stream-sidebar__item-content {
+  flex: 1;
   min-width: 0;
 }
 
@@ -64,6 +65,15 @@
 
 .stream-sidebar__item-preview {
   min-width: 0;
+  font-size: 0.8rem;
+  line-height: 1.4;
+  color: rgb(var(--app-ink-muted-rgb));
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  white-space: normal;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .stream-sidebar__status {
@@ -125,9 +135,33 @@
   min-width: 0;
 }
 
+.stream-sidebar__item-meta {
+  text-align: right;
+}
+
+.stream-sidebar__item-meta .app-badge {
+  align-self: flex-end;
+}
+
 .stream-sidebar__item-heading {
   min-width: 0;
   flex: 1;
+}
+
+.stream-sidebar__item-title {
+  margin: 0;
+  font-weight: 600;
+  color: rgb(var(--app-ink-rgb));
+  font-size: 0.95rem;
+  line-height: 1.3;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.stream-sidebar__item-time {
+  font-size: 0.75rem;
+  color: rgb(var(--app-ink-subtle-rgb));
 }
 
 .stream-status-dot {

--- a/frontend/src/components/TranscriptSegmentButton.scss
+++ b/frontend/src/components/TranscriptSegmentButton.scss
@@ -1,7 +1,7 @@
 .transcript-segment {
   display: inline-block;
   text-align: left;
-  padding: 0.1875rem 0.3rem;
+  padding: 0.15rem 0.25rem;
   border-radius: 0.75rem;
   border: 1px solid rgba(var(--transcript-segment-surface-border-rgb), 0.65);
   cursor: pointer;
@@ -24,19 +24,19 @@
 }
 
 .transcript-segment__time {
-  font-size: 0.75rem;
+  font-size: 0.7rem;
   font-family: 'Inter', system-ui, sans-serif;
   background-color: rgba(var(--transcript-segment-time-rgb), 0.8);
   color: rgb(var(--app-ink-subtle-rgb));
   border-radius: 0.5rem;
-  padding: 0.1rem 0.45rem;
-  margin-right: 0.4rem;
+  padding: 0.08rem 0.35rem;
+  margin-right: 0.35rem;
   white-space: nowrap;
 }
 
 .transcript-segment__text {
-  font-size: 0.95rem;
-  line-height: 1.35;
+  font-size: 0.9rem;
+  line-height: 1.3;
   transition: color 0.2s ease;
 }
 

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -371,6 +371,31 @@ a:hover {
   color: rgb(var(--app-neutral-rgb));
 }
 
+.app-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.5rem;
+  padding: 0.1rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  line-height: 1;
+  align-self: center;
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+.app-badge--accent {
+  background-color: rgb(var(--app-accent-rgb));
+  color: rgb(var(--app-on-accent-rgb));
+}
+
+.app-badge--neutral {
+  background-color: rgba(var(--app-neutral-rgb), 0.12);
+  color: rgb(var(--app-ink-rgb));
+}
+
 
 @media (max-width: 575.98px) {
   .toast-viewport {


### PR DESCRIPTION
## Summary
- tighten the stream management list spacing and typography with a dedicated stylesheet
- shrink transcript segment chip padding and text to feel less bulky
- restore the badge styles and sidebar metadata formatting that were lost during a rebase

## Testing
- npm run lint

## Screenshots
![Updated stream directory layout](browser:/invocations/iubaelpb/artifacts/artifacts/stream-directory.png)


------
https://chatgpt.com/codex/tasks/task_e_68d3900064e8832791d8497da1031b89