### PR TITLE
Add soft background color to stream sidebar items

### DIFF
--- a/frontend/src/components/StreamSidebar.scss
+++ b/frontend/src/components/StreamSidebar.scss
@@ -97,7 +97,7 @@
 
 .stream-sidebar__item {
   border: 0;
-  background: transparent;
+  background-color: rgba(var(--app-ink-rgb), 0.04);
   color: inherit;
   padding: 0.75rem;
   border-radius: 0.85rem;


### PR DESCRIPTION
## Summary
- add a subtle resting background to stream sidebar entries so they read as grouped cards

## Testing
- npm run lint
- npm run test

## Screenshots
![Stream list with subtle background](browser:/invocations/oynshyrh/artifacts/artifacts/stream-list.png)


------
https://chatgpt.com/codex/tasks/task_e_68d393c6d6e48327a0e41ec531c66139