### PR TITLE
Add pre-commit hook for type checking

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+mapfile -t STAGED_FILES < <(git diff --cached --name-only --diff-filter=ACM)
+
+run_ts=false
+run_py=false
+
+for file in "${STAGED_FILES[@]}"; do
+  case "$file" in
+    *.ts|*.tsx)
+      run_ts=true
+      ;;
+    *.py)
+      run_py=true
+      ;;
+  esac
+done
+
+if $run_ts; then
+  echo "Running TypeScript type check..."
+  npm --prefix frontend run type-check
+  echo "TypeScript type check completed."
+fi
+
+if $run_py; then
+  echo "Running Python type check..."
+  mapfile -t backend_py_files < <(printf '%s\n' "${STAGED_FILES[@]}" | sed -n 's/^backend\///p' | grep '\.py$' || true)
+  mapfile -t external_py_files < <(printf '%s\n' "${STAGED_FILES[@]}" | grep '\.py$' | grep -v '^backend/' || true)
+
+  if [ ${#backend_py_files[@]} -gt 0 ]; then
+    poetry -C backend run mypy "${backend_py_files[@]}"
+  fi
+
+  if [ ${#external_py_files[@]} -gt 0 ]; then
+    mapfile -t adjusted_external < <(printf '%s\n' "${external_py_files[@]}" | sed 's#^#../#')
+    poetry -C backend run mypy "${adjusted_external[@]}"
+  fi
+  echo "Python type check completed."
+fi
+
+exit 0

--- a/README.md
+++ b/README.md
@@ -40,6 +40,18 @@ chmod +x start-app.sh
 The helper script creates a Python virtual environment for the backend, installs dependencies, builds the frontend, and then
 launches `uvicorn` on the configured port (defaults to `8000`).
 
+### Git Hooks
+
+The repository ships the pre-commit hook under `.githooks/pre-commit`. Install it once per clone so commits run TypeScript and
+Python type checking automatically:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+After configuring the custom hook path, the pre-commit hook invokes `npm --prefix frontend run type-check` when TypeScript files
+are staged and `poetry -C backend run mypy` for staged Python files.
+
 ### Manual Start
 
 ```bash


### PR DESCRIPTION
## Summary
- add a repository-managed pre-commit hook that runs npm type-checks for TypeScript and mypy for Python files that are part of a commit
- document how to enable the shared git hooks and what the type-check automation covers

## Testing
- npm --prefix frontend run type-check

------
https://chatgpt.com/codex/tasks/task_e_68d489d490b88327a4d13a4f0c196ff8