### PR TITLE
Avoid BuildKit dockerfile directive to prevent auth error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,3 @@
-# syntax=docker/dockerfile:1
-
 #############################
 # Frontend build stage
 #############################


### PR DESCRIPTION
## Summary
- remove the remote BuildKit syntax directive from the Dockerfile so `docker compose build` no longer requires authenticating to Docker Hub

## Testing
- ⚠️ `docker compose build` *(fails in this environment because Docker is not installed)*

## Screenshots
- Not applicable; backend-only change with no UI impact and the execution environment lacks Docker support for launching the app.


------
https://chatgpt.com/codex/tasks/task_e_68d489fd5b88832795a4660ec709a4b8