### PR TITLE
Force Whisper CPU fallback when CUDA runtime missing

### DIFF
--- a/backend/tests/test_whisper_transcriber.py
+++ b/backend/tests/test_whisper_transcriber.py
@@ -121,6 +121,11 @@ class _NoTemperatureIncrementModel:
 def test_preload_gpu_failure_falls_back_to_cpu(monkeypatch):
     _GpuThenCpuModel.reset()
     monkeypatch.setattr(module, "WhisperModel", _GpuThenCpuModel)
+    monkeypatch.setattr(
+        module.WhisperTranscriber,
+        "_gpu_runtime_available",
+        lambda self: True,
+    )
     config = WhisperConfig(model="large-v3-turbo", cpuFallbackModel="base")
 
     transcriber = module.WhisperTranscriber(config)
@@ -141,6 +146,11 @@ async def _run_transcribe(transcriber: module.WhisperTranscriber) -> None:
 def test_lazy_initialization_gpu_failure_recovers_with_cpu(monkeypatch):
     _GpuThenCpuModel.reset()
     monkeypatch.setattr(module, "WhisperModel", _GpuThenCpuModel)
+    monkeypatch.setattr(
+        module.WhisperTranscriber,
+        "_gpu_runtime_available",
+        lambda self: True,
+    )
     config = WhisperConfig(model="small", cpuFallbackModel=None)
     transcriber = module.WhisperTranscriber(config, preload_model=False)
 


### PR DESCRIPTION
## Summary
- skip GPU initialisation when ctranslate2 reports no CUDA devices and load the CPU (or configured fallback) Whisper model instead
- centralise CPU model creation and extend logging around fallback decisions for clearer diagnostics
- adjust Whisper transcriber tests to stub GPU availability so GPU failure paths remain covered

## Testing
- `cd backend && pytest`

## Screenshots
- Not captured (backend-only change; no UI impact)


------
https://chatgpt.com/codex/tasks/task_e_68d4930462008327b2fc6932082a253a