### PR TITLE
Silence Sass color function deprecation warnings

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -5,6 +5,13 @@ import path from "path";
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  css: {
+    preprocessorOptions: {
+      scss: {
+        silenceDeprecations: ["color-functions"],
+      },
+    },
+  },
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
## Summary
- silence the Sass color function deprecation warnings during the Vite build by adding a `silenceDeprecations` option for SCSS preprocessing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d492f0889083279435d087a7716968