### PR TITLE
Show pager export action in stream view

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -961,6 +961,12 @@ function App() {
     () => isPagerStream(selectedStream),
     [selectedStream],
   );
+
+  useEffect(() => {
+    if (selectedStream && isPagerStream(selectedStream)) {
+      selectPagerExportStream(selectedStream.id);
+    }
+  }, [selectedStream, selectPagerExportStream]);
   const selectedStreamWebhookUrl = useMemo(() => {
     if (!selectedStream || !canViewWebhookDetails) {
       return null;
@@ -1782,6 +1788,9 @@ function App() {
                       onReviewTranscription={reviewTranscription}
                       focusStreamId={selectedStream.id}
                       onStandaloneControlsChange={setStandaloneControls}
+                      pagerExporting={exportingPagerFeed}
+                      onExportPagerFeed={exportPagerFeed}
+                      onSelectPagerExportStream={selectPagerExportStream}
                     />
                   ) : (
                     <div className="conversation-panel__placeholder text-body-secondary text-center">

--- a/frontend/src/components/StreamTranscriptionPanel.react.tsx
+++ b/frontend/src/components/StreamTranscriptionPanel.react.tsx
@@ -29,6 +29,7 @@ import {
   MicOff,
   Wifi,
   WifiOff,
+  Download,
 } from "lucide-react";
 import {
   Stream,
@@ -102,6 +103,9 @@ interface StreamTranscriptionPanelProps {
   onStandaloneControlsChange?: (
     controls: StandaloneStreamControls | null,
   ) => void;
+  onExportPagerFeed?: () => Promise<void> | void;
+  onSelectPagerExportStream?: (streamId: string) => void;
+  pagerExporting?: boolean;
 }
 
 const INITIAL_HISTORY_WINDOW_MINUTES = 180;
@@ -223,6 +227,9 @@ export const StreamTranscriptionPanel = ({
   onReviewTranscription,
   focusStreamId,
   onStandaloneControlsChange,
+  onExportPagerFeed,
+  onSelectPagerExportStream,
+  pagerExporting = false,
 }: StreamTranscriptionPanelProps) => {
   const { authFetch, role, authenticated, requiresPassword } = useAuth();
   const isReadOnly = role !== "editor";
@@ -1494,6 +1501,33 @@ export const StreamTranscriptionPanel = ({
       </Button>,
     ];
 
+    if (isPagerStream(focusedVisibleStream) && onExportPagerFeed) {
+      toolButtonItems.push(
+        <Button
+          key="export-pager"
+          size="sm"
+          use="secondary"
+          appearance="outline"
+          onClick={() => {
+            onSelectPagerExportStream?.(streamId);
+            void onExportPagerFeed();
+          }}
+          startContent={
+            pagerExporting ? (
+              <Loader2 className="w-3 h-3 animate-spin" aria-hidden="true" />
+            ) : (
+              <Download size={14} />
+            )
+          }
+          isCondensed
+          tooltip="Export pager feed"
+          disabled={pagerExporting}
+        >
+          {pagerExporting ? "Exporting…" : "Export feed"}
+        </Button>,
+      );
+    }
+
     const toolButtons =
       toolButtonItems.length > 0 ? (
         <ButtonGroup size="sm">{toolButtonItems}</ButtonGroup>
@@ -1783,6 +1817,9 @@ export const StreamTranscriptionPanel = ({
     setOpenStandaloneTool,
     openStandaloneTool,
     isReadOnly,
+    onExportPagerFeed,
+    onSelectPagerExportStream,
+    pagerExporting,
   ]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- sync the pager feed selection with the active conversation stream
- surface an "Export feed" control alongside other pager stream tools

## Testing
- npm run lint

## Screenshots
![Pager stream export control](browser:/invocations/flkvvqnx/artifacts/artifacts/pager-export-button.png)

------
https://chatgpt.com/codex/tasks/task_e_68d4cad7044c8327804404595a600242