### PR TITLE
Condense pager fragments into structured summaries

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -66,6 +66,9 @@ transcribing multiple radio or pager feeds in real time.
 - CFS Flex submissions extract incident numbers, call types, map grids,
   talkgroups, narratives, and responding units from the raw FLEX string while
   preserving the original pager line in the transcript details.
+- Pager streams condense fragments that arrive within a few seconds into a
+  single structured summary while keeping the original fragments available for
+  review on demand.
 - Export reviewed transcripts as a ZIP with audio via header controls, choosing corrected, verified, or pending items.
 - Export pager feeds as ZIP archives from the settings modal; downloads include JSONL pager messages and incident details.
 - `python -m wavecap_backend.tools.export_transcriptions --output-dir <path>` builds a fine-tuning dataset with JSONL metadata, optional audio copies, and notebook guidance.

--- a/frontend/src/components/StreamTranscriptionPanel.logic.ts
+++ b/frontend/src/components/StreamTranscriptionPanel.logic.ts
@@ -8,6 +8,23 @@ export const MAX_SILENCE_MS = 6000;
 export const GAP_MULTIPLIER = 1.6;
 export const DURATION_SILENCE_SCALE = 0.6;
 export const PAGER_INCIDENT_GROUP_WINDOW_MS = 90_000;
+export const PAGER_SIMULTANEOUS_WINDOW_MS = 5_000;
+
+export interface CondensedPagerField {
+  key: string;
+  label: string;
+  values: string[];
+  format?: "text" | "code";
+}
+
+export interface CondensedPagerMessage {
+  id: string;
+  timestamp: string;
+  summary: string | null;
+  fields: CondensedPagerField[];
+  notes: string[];
+  fragments: TranscriptionResult[];
+}
 
 export interface TranscriptionGroup {
   id: string;
@@ -173,6 +190,288 @@ export const getBlankAudioSegmentBounds = (
     start: startOffset,
     end: endOffset,
   };
+};
+
+const normalisePagerFieldKey = (label: string): string => {
+  const base = label.toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+  switch (base) {
+    case "raw":
+    case "raw_message":
+    case "rawmessage":
+      return "raw_message";
+    case "talk_group":
+    case "talkgroup":
+    case "tg":
+      return "talkgroup";
+    case "alarm":
+    case "alarm_level":
+      return "alarm_level";
+    default:
+      return base;
+  }
+};
+
+const normalisePagerFieldLabel = (key: string, fallback: string): string => {
+  switch (key) {
+    case "map":
+      return "Map";
+    case "talkgroup":
+      return "Talkgroup";
+    case "priority":
+      return "Priority";
+    case "narrative":
+      return "Narrative";
+    case "units":
+      return "Units";
+    case "raw_message":
+      return "Raw message";
+    case "address":
+      return "Address";
+    case "alarm_level":
+      return "Alarm level";
+    default:
+      return fallback;
+  }
+};
+
+const PAGER_FIELD_ORDER: Record<string, number> = {
+  map: 10,
+  talkgroup: 20,
+  address: 30,
+  alarm_level: 40,
+  priority: 50,
+  narrative: 60,
+  units: 70,
+  raw_message: 80,
+};
+
+const PART_SUFFIX_PATTERN = /\s*\(Part\s+\d+\s+of\s+\d+\)\s*$/i;
+
+const sanitizePagerValue = (value: string): string =>
+  value.replace(PART_SUFFIX_PATTERN, "").trim();
+
+interface ParsedPagerFragment {
+  summary: string | null;
+  fields: { label: string; value: string; format?: "text" | "code" }[];
+  notes: string[];
+}
+
+const parsePagerFragment = (text: string): ParsedPagerFragment => {
+  const lines = text.split(/\r?\n/);
+  let summary: string | null = null;
+  const fields: { label: string; value: string; format?: "text" | "code" }[] = [];
+  const notes: string[] = [];
+
+  lines.forEach((rawLine, index) => {
+    const trimmed = rawLine.trim();
+    if (!trimmed) {
+      return;
+    }
+
+    const bulletMatch = /^•\s*(.*)$/u.exec(trimmed);
+    const content = bulletMatch ? bulletMatch[1].trim() : trimmed;
+
+    if (!summary && !bulletMatch && !/^priority\b/i.test(content)) {
+      summary = content;
+      return;
+    }
+
+    const colonIndex = content.indexOf(":");
+    if (colonIndex > 0 && colonIndex < content.length - 1) {
+      const label = content.slice(0, colonIndex).trim();
+      const value = content.slice(colonIndex + 1).trim();
+      if (value) {
+        const format = /raw\s*message/i.test(label) ? "code" : "text";
+        fields.push({ label, value, format });
+      }
+      return;
+    }
+
+    const priorityMatch = /^priority\s*(.*)$/i.exec(content);
+    if (priorityMatch) {
+      const value = priorityMatch[1].replace(/^[:\s]+/, "").trim();
+      if (value) {
+        fields.push({ label: "Priority", value });
+      }
+      return;
+    }
+
+    const talkgroupMatch = /^talkgroup\s+(.+)$/i.exec(content);
+    if (talkgroupMatch) {
+      fields.push({ label: "Talkgroup", value: talkgroupMatch[1].trim() });
+      return;
+    }
+
+    const narrativeMatch = /^==\s*(.+)$/i.exec(content);
+    if (narrativeMatch) {
+      fields.push({ label: "Narrative", value: narrativeMatch[1].trim() });
+      return;
+    }
+
+    if (!summary && index === 0) {
+      summary = content;
+      return;
+    }
+
+    notes.push(content);
+  });
+
+  return { summary, fields, notes };
+};
+
+const appendPagerField = (
+  fieldMap: Map<string, CondensedPagerField>,
+  label: string,
+  value: string,
+  format: "text" | "code" = "text",
+) => {
+  const cleanedValue = sanitizePagerValue(value);
+  if (!cleanedValue) {
+    return;
+  }
+
+  const normalisedKey = normalisePagerFieldKey(label);
+  const key = normalisedKey || label.toLowerCase();
+  const displayLabel = normalisePagerFieldLabel(key, label.trim());
+  const existing = fieldMap.get(key);
+
+  if (existing) {
+    if (!existing.values.some((item) => item.toLowerCase() === cleanedValue.toLowerCase())) {
+      existing.values.push(cleanedValue);
+    }
+    if (format === "code") {
+      existing.format = "code";
+    }
+    return;
+  }
+
+  fieldMap.set(key, {
+    key,
+    label: displayLabel,
+    values: [cleanedValue],
+    format,
+  });
+};
+
+export const condensePagerTranscriptions = (
+  transcriptions: TranscriptionResult[],
+): CondensedPagerMessage[] => {
+  if (transcriptions.length === 0) {
+    return [];
+  }
+
+  const sorted = [...transcriptions].sort(
+    (a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime(),
+  );
+
+  interface PagerCluster {
+    transcriptions: TranscriptionResult[];
+    lastTimestampMs: number;
+  }
+
+  const clusters: PagerCluster[] = [];
+
+  sorted.forEach((transcription) => {
+    const timestampMs = new Date(transcription.timestamp).getTime();
+    if (Number.isNaN(timestampMs)) {
+      return;
+    }
+
+    const lastCluster = clusters[clusters.length - 1];
+    if (
+      !lastCluster ||
+      timestampMs - lastCluster.lastTimestampMs > PAGER_SIMULTANEOUS_WINDOW_MS
+    ) {
+      clusters.push({
+        transcriptions: [transcription],
+        lastTimestampMs: timestampMs,
+      });
+      return;
+    }
+
+    lastCluster.transcriptions.push(transcription);
+    lastCluster.lastTimestampMs = timestampMs;
+  });
+
+  return clusters.map((cluster) => {
+    const fieldMap = new Map<string, CondensedPagerField>();
+    const noteSet = new Set<string>();
+    let summary: string | null = null;
+
+    cluster.transcriptions.forEach((transcription) => {
+      const parsed = parsePagerFragment(transcription.text ?? "");
+      if (!summary && parsed.summary) {
+        summary = parsed.summary;
+      } else if (parsed.summary && parsed.summary !== summary) {
+        noteSet.add(parsed.summary);
+      }
+
+      parsed.fields.forEach(({ label, value, format }) => {
+        appendPagerField(fieldMap, label, value, format);
+      });
+      parsed.notes.forEach((note) => {
+        const cleaned = sanitizePagerValue(note);
+        if (cleaned) {
+          noteSet.add(cleaned);
+        }
+      });
+    });
+
+    const incident = cluster.transcriptions.find((item) => item.pagerIncident)?.pagerIncident;
+    if (incident) {
+      if (!summary) {
+        const summaryParts = [incident.incidentId, incident.callType, incident.address]
+          .map((value) => (value ? value.trim() : ""))
+          .filter((value) => value);
+        if (incident.alarmLevel) {
+          summaryParts.push(`Alarm level ${incident.alarmLevel}`);
+        }
+        if (summaryParts.length > 0) {
+          summary = summaryParts.join(" – ");
+        }
+      }
+
+      if (incident.map) {
+        appendPagerField(fieldMap, "Map", incident.map);
+      }
+      if (incident.talkgroup) {
+        appendPagerField(fieldMap, "Talkgroup", incident.talkgroup);
+      }
+      if (incident.address) {
+        appendPagerField(fieldMap, "Address", incident.address);
+      }
+      if (incident.alarmLevel) {
+        appendPagerField(fieldMap, "Alarm level", incident.alarmLevel);
+      }
+      if (incident.narrative) {
+        appendPagerField(fieldMap, "Narrative", incident.narrative);
+      }
+      if (incident.units) {
+        appendPagerField(fieldMap, "Units", incident.units);
+      }
+      if (incident.rawMessage) {
+        appendPagerField(fieldMap, "Raw message", incident.rawMessage, "code");
+      }
+    }
+
+    const fields = Array.from(fieldMap.values()).sort((a, b) => {
+      const rankA = PAGER_FIELD_ORDER[a.key] ?? 100;
+      const rankB = PAGER_FIELD_ORDER[b.key] ?? 100;
+      if (rankA === rankB) {
+        return a.label.localeCompare(b.label);
+      }
+      return rankA - rankB;
+    });
+
+    return {
+      id: cluster.transcriptions[0].id,
+      timestamp: cluster.transcriptions[0].timestamp,
+      summary,
+      fields,
+      notes: Array.from(noteSet),
+      fragments: cluster.transcriptions,
+    } satisfies CondensedPagerMessage;
+  });
 };
 
 const shouldIsolateTranscription = (

--- a/frontend/src/components/StreamTranscriptionPanel.scss
+++ b/frontend/src/components/StreamTranscriptionPanel.scss
@@ -608,6 +608,118 @@
   font-weight: 500;
 }
 
+.transcript-thread__pager-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  width: 100%;
+}
+
+.pager-transcript {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.75rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(var(--bs-border-color-rgb, 222, 226, 230), 0.6);
+  background-color: rgba(var(--app-surface-strong-rgb, 246, 249, 252), 0.6);
+  box-shadow: inset 0 0 0 1px rgba(var(--app-surface-strong-rgb, 246, 249, 252), 0.4);
+}
+
+.pager-transcript__summary {
+  font-weight: 600;
+  color: rgb(var(--app-ink-rgb));
+  font-size: 0.95rem;
+}
+
+.pager-transcript__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.pager-transcript__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.pager-transcript__details {
+  display: grid;
+  gap: 0.4rem 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+  font-size: 0.85rem;
+}
+
+.pager-transcript__detail {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.pager-transcript__detail dt {
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgb(var(--app-ink-subtle-rgb));
+}
+
+.pager-transcript__detail dd {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  word-break: break-word;
+  color: rgb(var(--app-ink-rgb));
+}
+
+.pager-transcript__detail code {
+  font-size: 0.75rem;
+  padding: 0.15rem 0.35rem;
+  border-radius: 0.4rem;
+  background-color: rgba(var(--app-ink-muted-rgb), 0.08);
+}
+
+.pager-transcript__notes {
+  margin: 0;
+  padding-left: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.8rem;
+  color: rgb(var(--app-ink-muted-rgb));
+}
+
+.pager-transcript__fragments {
+  font-size: 0.75rem;
+  color: rgb(var(--app-ink-subtle-rgb));
+}
+
+.pager-transcript__fragments summary {
+  cursor: pointer;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+.pager-transcript__fragments summary::marker,
+.pager-transcript__fragments summary::-webkit-details-marker {
+  display: none;
+}
+
+.pager-transcript__fragments[open] summary {
+  color: rgb(var(--app-ink-rgb));
+}
+
+.pager-transcript__fragment-list {
+  margin-top: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
 .transcript-scroll-area {
   position: relative;
   display: flex;


### PR DESCRIPTION
## Summary
- add pager condensation utilities to merge fragments and expose structured fields
- render condensed pager messages with a dedicated layout and keep original fragments accessible on demand
- cover the new behaviour with unit tests and document it in SPEC

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d4cfb3b2dc8327855a0514114e116f