### PR TITLE
Improve pager transcript presentation

### DIFF
--- a/frontend/src/components/StreamTranscriptionPanel.react.tsx
+++ b/frontend/src/components/StreamTranscriptionPanel.react.tsx
@@ -11,6 +11,7 @@ import {
 import {
   ChevronDown,
   ChevronRight,
+  ChevronUp,
   Radio,
   Clock,
   Activity,
@@ -308,6 +309,9 @@ export const StreamTranscriptionPanel = ({
   const [liveAudioErrorByStream, setLiveAudioErrorByStream] = useState<
     Record<string, string | null>
   >({});
+  const [openPagerMessageIds, setOpenPagerMessageIds] = useState<
+    Record<string, boolean>
+  >({});
   const [activeSearchPanelStreamId, setActiveSearchPanelStreamId] = useState<
     string | null
   >(null);
@@ -315,6 +319,13 @@ export const StreamTranscriptionPanel = ({
     useState<StandaloneTool | null>(null);
   const liveAudioRefs = useRef<Record<string, HTMLAudioElement | null>>({});
   const recordingAudioRefs = useRef<Record<string, HTMLAudioElement | null>>({});
+
+  const togglePagerMessageFragments = useCallback((messageId: string) => {
+    setOpenPagerMessageIds((previous) => ({
+      ...previous,
+      [messageId]: !previous[messageId],
+    }));
+  }, []);
 
   const shouldAutoScrollFocusedView = Boolean(focusStreamId);
   const {
@@ -2272,6 +2283,12 @@ export const StreamTranscriptionPanel = ({
                     (message.fragments[0]?.text
                       ? message.fragments[0].text.split(/\r?\n/, 1)[0]
                       : "Pager update");
+                  const isFragmentsOpen = Boolean(
+                    openPagerMessageIds[message.id],
+                  );
+                  const fragmentCountLabel = `${message.fragments.length} ${
+                    message.fragments.length === 1 ? "fragment" : "fragments"
+                  }`;
 
                   return (
                     <div key={message.id} className="pager-transcript">
@@ -2321,14 +2338,44 @@ export const StreamTranscriptionPanel = ({
                         </ul>
                       ) : null}
                       {fragmentElements.length > 0 ? (
-                        <details className="pager-transcript__fragments">
-                          <summary>
-                            Show raw fragments ({message.fragments.length})
-                          </summary>
-                          <div className="pager-transcript__fragment-list">
-                            {fragmentElements}
-                          </div>
-                        </details>
+                        <div
+                          className={`pager-transcript__fragments${
+                            isFragmentsOpen
+                              ? " pager-transcript__fragments--open"
+                              : ""
+                          }`}
+                        >
+                          <Button
+                            use="secondary"
+                            appearance="outline"
+                            size="sm"
+                            className={`pager-transcript__fragments-toggle${
+                              isFragmentsOpen
+                                ? " pager-transcript__fragments-toggle--open"
+                                : ""
+                            }`}
+                            startContent={
+                              isFragmentsOpen ? (
+                                <ChevronUp size={14} />
+                              ) : (
+                                <ChevronDown size={14} />
+                              )
+                            }
+                            onClick={() => togglePagerMessageFragments(message.id)}
+                          >
+                            {isFragmentsOpen ? "Hide raw message" : "View raw message"}
+                            <span className="pager-transcript__fragment-count">
+                              {fragmentCountLabel}
+                            </span>
+                          </Button>
+                          {isFragmentsOpen ? (
+                            <div className="pager-transcript__fragment-panel">
+                              <div className="pager-transcript__fragment-list">
+                                {fragmentElements}
+                              </div>
+                            </div>
+                          ) : null}
+                        </div>
                       ) : null}
                     </div>
                   );

--- a/frontend/src/components/StreamTranscriptionPanel.scss
+++ b/frontend/src/components/StreamTranscriptionPanel.scss
@@ -692,29 +692,69 @@
 }
 
 .pager-transcript__fragments {
-  font-size: 0.75rem;
-  color: rgb(var(--app-ink-subtle-rgb));
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  margin-top: 0.35rem;
+  padding-top: 0.6rem;
+  border-top: 1px solid rgba(var(--bs-border-color-rgb, 222, 226, 230), 0.6);
 }
 
-.pager-transcript__fragments summary {
-  cursor: pointer;
+.pager-transcript__fragments--open {
+  border-top-color: rgba(var(--bs-border-color-rgb, 222, 226, 230), 0.8);
+}
+
+.pager-transcript__fragments-toggle {
+  font-size: 0.75rem;
   font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
   display: inline-flex;
   align-items: center;
-  gap: 0.3rem;
+  gap: 0.35rem;
+  border-radius: 999px;
+  padding-inline: 0.75rem;
+  padding-block: 0.35rem;
+  border-color: rgba(var(--bs-border-color-rgb, 222, 226, 230), 0.75);
+  color: rgb(var(--app-ink-subtle-rgb));
+  background-color: rgba(var(--app-surface-rgb), 0.65);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
 }
 
-.pager-transcript__fragments summary::marker,
-.pager-transcript__fragments summary::-webkit-details-marker {
-  display: none;
-}
-
-.pager-transcript__fragments[open] summary {
+.pager-transcript__fragments-toggle:hover,
+.pager-transcript__fragments-toggle:focus-visible {
   color: rgb(var(--app-ink-rgb));
+  border-color: rgba(var(--bs-border-color-rgb, 222, 226, 230), 0.9);
+  background-color: rgba(var(--app-surface-strong-rgb, 246, 249, 252), 0.8);
+}
+
+.pager-transcript__fragments-toggle--open {
+  color: rgb(var(--app-ink-rgb));
+  background-color: rgba(var(--app-surface-strong-rgb, 246, 249, 252), 0.95);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.75);
+}
+
+.pager-transcript__fragment-count {
+  font-size: 0.7rem;
+  font-weight: 500;
+  letter-spacing: normal;
+  text-transform: none;
+  color: rgb(var(--app-ink-muted-rgb));
+}
+
+.pager-transcript__fragment-panel {
+  border-radius: 0.65rem;
+  border: 1px solid rgba(var(--bs-border-color-rgb, 222, 226, 230), 0.75);
+  background: linear-gradient(
+    135deg,
+    rgba(var(--app-surface-strong-rgb, 246, 249, 252), 0.95),
+    rgba(var(--app-surface-rgb), 0.9)
+  );
+  padding: 0.65rem 0.75rem;
+  box-shadow: 0 8px 16px -12px rgba(15, 23, 42, 0.65);
 }
 
 .pager-transcript__fragment-list {
-  margin-top: 0.5rem;
   display: flex;
   flex-direction: column;
   gap: 0.35rem;


### PR DESCRIPTION
## Summary
- add stateful toggle for pager fragments so raw messages open in a styled drawer instead of inline details
- refine pager transcript styling with pill toggle button and highlighted fragment panel for cleaner presentation

## Testing
- npm run lint

## Screenshots
![Updated pager transcript styling](browser:/invocations/nfdfnbty/artifacts/artifacts/pager-ui.png)


------
https://chatgpt.com/codex/tasks/task_e_68d4d35e9adc8327be1284e627f796a3