### PR TITLE
Filter initial prompt hallucinations

### DIFF
--- a/backend/tests/test_stream_worker.py
+++ b/backend/tests/test_stream_worker.py
@@ -1001,6 +1001,20 @@ async def test_worker_discards_hallucinated_silence(tmp_path):
     assert len(transcriber.calls) == 1
 
 
+def test_prepare_hallucination_phrases_includes_initial_prompt() -> None:
+    prompt = (
+        "Priority callouts include Adelaide, Adelaide fire out, Noarlunga, and "
+        "SITREP. Spell them exactly when they are heard on air."
+    )
+    phrases = StreamWorker._prepare_hallucination_phrases([], prompt)
+    normalized_prompt = StreamWorker._normalize_hallucination_phrase(prompt)
+    normalized_sentence = StreamWorker._normalize_hallucination_phrase(
+        "Spell them exactly when they are heard on air"
+    )
+    assert normalized_prompt in phrases
+    assert normalized_sentence in phrases
+
+
 @pytest.mark.asyncio
 async def test_worker_discards_all_right_here_we_go_hallucination(tmp_path):
     config = WhisperConfig(
@@ -1025,6 +1039,73 @@ async def test_worker_discards_all_right_here_we_go_hallucination(tmp_path):
 
     stream = Stream(
         id="stream-hallucination-all-right",
+        name="Hallucination",
+        url="http://example.com/audio",
+        status=StreamStatus.STOPPED,
+        createdAt=datetime.utcnow(),
+        transcriptions=[],
+        source=StreamSource.AUDIO,
+    )
+
+    db = StreamDatabase(tmp_path / "runtime.sqlite")
+    evaluator = TranscriptionAlertEvaluator(AlertsConfig(enabled=False, rules=[]))
+    captured: List[TranscriptionResult] = []
+
+    async def capture(transcription: TranscriptionResult) -> None:
+        captured.append(transcription)
+
+    async def noop_status(_stream: Stream, _status: StreamStatus) -> None:
+        return
+
+    worker = StreamWorker(
+        stream=stream,
+        transcriber=transcriber,
+        database=db,
+        alert_evaluator=evaluator,
+        on_transcription=capture,
+        on_status_change=noop_status,
+        config=config,
+    )
+
+    silence = np.zeros(16000, dtype=np.int16).tobytes()
+
+    await worker._ingest_pcm_bytes(silence)
+
+    assert len(captured) == 1
+    result = captured[0]
+    assert result.text == BLANK_AUDIO_TOKEN
+    assert result.segments is None
+    assert result.recordingUrl is None
+    assert len(transcriber.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_worker_discards_initial_prompt_hallucination(tmp_path):
+    prompt = (
+        "Priority callouts include Adelaide, Adelaide fire out, Noarlunga, and "
+        "SITREP. Spell them exactly when they are heard on air."
+    )
+    config = WhisperConfig(
+        sampleRate=16000,
+        chunkLength=4,
+        minChunkDurationSeconds=1.0,
+        contextSeconds=0.0,
+        silenceThreshold=0.01,
+        silenceLookbackSeconds=0.25,
+        silenceHoldSeconds=0.25,
+        activeSamplesInLookbackPct=0.1,
+        blankAudioMinDurationSeconds=0.5,
+        blankAudioMinActiveRatio=0.0,
+        blankAudioMinRms=0.0,
+        silenceHallucinationPhrases=[],
+        initialPrompt=prompt,
+    )
+
+    bundle = TranscriptionResultBundle(prompt, [], "en", no_speech_prob=0.2)
+    transcriber = StubTranscriber([bundle])
+
+    stream = Stream(
+        id="stream-hallucination-initial-prompt",
         name="Hallucination",
         url="http://example.com/audio",
         status=StreamStatus.STOPPED,


### PR DESCRIPTION
## Summary
- add initial prompt sentences to the hallucination phrase filter so Whisper echoes of the correction prompt are dropped
- cover the new filtering rules with unit tests for the phrase preparation helper and end-to-end chunk ingestion

## Testing
- `cd backend && PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d4d3afd6bc832785efa313905846fb