### PR TITLE
Suppress low-energy hallucinated transcripts

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -37,6 +37,7 @@ transcribing multiple radio or pager feeds in real time.
   collapse into a single grouped thread, showing parsed incident details like the call
   type, location, and alarm level alongside the individual updates.
 - When Whisper returns no text but audio passes silence thresholds, show a "Silence" entry with playback controls. If the clip contains noisy speech Whisper cannot decode, surface it as `[unable to transcribe]` and keep the recording for operators to replay.
+- Suppress hallucinated phrases on barely audible bursts; if a chunk lacks meaningful energy the backend drops Whisper's text entirely so the transcript log stays empty instead of fabricating callouts.
 - Load roughly the last three hours of transcripts per stream on initial view and fetch older history on demand (including auto-loading when needed) to keep the interface responsive. Loaded transcripts persist until refresh or reset; the toolbar no longer clears local history.
 - When a browser tab stays hidden for about fifteen minutes, the UI releases its WebSocket connection and reconnects automatically (refreshing stream data) as soon as the operator returns to the tab.
 - Get banners and chimes for configured keywords such as "Mayday" or "Pan-Pan."


### PR DESCRIPTION
## Summary
- drop Whisper output on low-energy chunks to avoid hallucinated callouts
- cover the low-energy suppression path with a regression test
- document the behavior in the product specification

## Testing
- PYTHONPATH=src poetry run pytest tests/test_stream_worker.py

## Screenshot
![Screenshot showing SPEC documentation update](browser:/invocations/vubmpvbu/artifacts/artifacts/low-energy-spec.png)

------
https://chatgpt.com/codex/tasks/task_e_68d55a8052f88327a238e973c1027dba