### PR TITLE
Hide raw pager message detail from transcript list

### DIFF
--- a/frontend/src/components/StreamTranscriptionPanel.react.tsx
+++ b/frontend/src/components/StreamTranscriptionPanel.react.tsx
@@ -2292,6 +2292,10 @@ export const StreamTranscriptionPanel = ({
                     message.fragments.length === 1 ? "fragment" : "fragments"
                   }`;
 
+                  const detailFields = message.fields.filter(
+                    (field) => field.key !== "raw_message",
+                  );
+
                   return (
                     <div key={message.id} className="pager-transcript">
                       {summaryText ? (
@@ -2303,9 +2307,9 @@ export const StreamTranscriptionPanel = ({
                           {alertChips}
                         </div>
                       ) : null}
-                      {message.fields.length > 0 ? (
+                      {detailFields.length > 0 ? (
                         <dl className="pager-transcript__details">
-                          {message.fields.map((field) => (
+                          {detailFields.map((field) => (
                             <div
                               key={`${message.id}-${field.key}`}
                               className="pager-transcript__detail"


### PR DESCRIPTION
## Summary
- stop rendering "Raw message" entries in pager transcript detail lists so the information only appears in the raw message toggle

## Testing
- `npm run test`

## Screenshots
![Pager transcript without duplicated raw message field](browser:/invocations/biqbzsry/artifacts/artifacts/wavecap-pager.png)


------
https://chatgpt.com/codex/tasks/task_e_68d5ea434cd483279a753d5d4a929831