### PR TITLE
Clarify South Australia emergency context in preprompt

### DIFF
--- a/backend/default-config.yaml
+++ b/backend/default-config.yaml
@@ -48,10 +48,10 @@ whisper:
   temperatureIncrementOnFallback: 0.2
   conditionOnPreviousText: false
   initialPrompt: >-
-    These transcripts capture firefighter and other emergency services radio
-    traffic in South Australia. Priority callouts include Adelaide, Adelaide
-    fire out, Noarlunga, and SITREP. Spell them exactly when they are heard on
-    air.
+    This is part of an emergency radio conversation between firefighters and
+    other emergency services in South Australia. Priority callouts include
+    Adelaide, Adelaide fire out, Noarlunga, SITREP, SAPOL, and SES. Spell them
+    exactly when they are heard on air.
   # Front-end filtering keeps speech crisp and level.
   highpassCutoffHz: 250
   lowpassCutoffHz: 3800

--- a/backend/default-config.yaml
+++ b/backend/default-config.yaml
@@ -48,8 +48,10 @@ whisper:
   temperatureIncrementOnFallback: 0.2
   conditionOnPreviousText: false
   initialPrompt: >-
-    Priority callouts include Adelaide, Adelaide fire out, Noarlunga, and
-    SITREP. Spell them exactly when they are heard on air.
+    These transcripts capture firefighter and other emergency services radio
+    traffic in South Australia. Priority callouts include Adelaide, Adelaide
+    fire out, Noarlunga, and SITREP. Spell them exactly when they are heard on
+    air.
   # Front-end filtering keeps speech crisp and level.
   highpassCutoffHz: 250
   lowpassCutoffHz: 3800


### PR DESCRIPTION
## Summary
- clarify the default initialPrompt so language models know the transcripts cover South Australian firefighter and emergency services radio traffic

## Testing
- not run (configuration-only change)

## Screenshots
![Preprompt context card](browser:/invocations/qefeolfv/artifacts/artifacts/preprompt-update.png)


------
https://chatgpt.com/codex/tasks/task_e_68d5eb7c63988327a13a43b9ca482610