### PR TITLE
Clarify repetition filter settings

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -37,6 +37,7 @@ transcribing multiple radio or pager feeds in real time.
   collapse into a single grouped thread, showing parsed incident details like the call
   type, location, and alarm level alongside the individual updates.
 - When Whisper returns no text but audio passes silence thresholds, show a "Silence" entry with playback controls. If the clip contains noisy speech Whisper cannot decode, surface it as `[unable to transcribe]` and keep the recording for operators to replay.
+- Segments that loop the same long phrase beyond configured repetition limits are treated as `[unable to transcribe]` entries so the log highlights bursts Whisper could not confidently decode.
 - Suppress hallucinated phrases on barely audible bursts; if a chunk lacks meaningful energy the backend drops Whisper's text entirely so the transcript log stays empty instead of fabricating callouts.
 - Load roughly the last three hours of transcripts per stream on initial view and fetch older history on demand (including auto-loading when needed) to keep the interface responsive. Loaded transcripts persist until refresh or reset; the toolbar no longer clears local history.
 - When a browser tab stays hidden for about fifteen minutes, the UI releases its WebSocket connection and reconnects automatically (refreshing stream data) as soon as the operator returns to the tab.

--- a/backend/default-config.yaml
+++ b/backend/default-config.yaml
@@ -65,6 +65,10 @@ whisper:
     - "alright here we go"
     - "all right let's go"
     - "alright let's go"
+  # Treat segments that repeat the same phrase longer than this many characters
+  # more than the allowed count as untranscribable noise.
+  segmentRepetitionMinCharacters: 16
+  segmentRepetitionMaxAllowedConsecutiveRepeats: 4
 
 ui:
   themeMode: system

--- a/backend/src/wavecap_backend/models.py
+++ b/backend/src/wavecap_backend/models.py
@@ -7,6 +7,7 @@ from enum import Enum
 from typing import List, Optional
 
 from pydantic import (
+    AliasChoices,
     BaseModel,
     ConfigDict,
     Field,
@@ -318,6 +319,35 @@ class WhisperConfig(APIModel):
         default=75.0, alias="deemphasisTimeConstantMicros"
     )
     agcTargetRms: Optional[float] = Field(default=None, alias="agcTargetRms")
+    segmentRepetitionMinCharacters: int = Field(
+        default=16, alias="segmentRepetitionMinCharacters"
+    )
+    segmentRepetitionMaxAllowedConsecutiveRepeats: int = Field(
+        default=4,
+        alias="segmentRepetitionMaxAllowedConsecutiveRepeats",
+        validation_alias=AliasChoices(
+            "segmentRepetitionMaxAllowedConsecutiveRepeats",
+            "segmentRepetitionMaxRepeats",
+        ),
+    )
+
+    @field_validator("segmentRepetitionMinCharacters")
+    @classmethod
+    def _validate_segment_repetition_min_characters(cls, value: int) -> int:
+        parsed = int(value)
+        if parsed < 0:
+            raise ValueError("segmentRepetitionMinCharacters must be non-negative")
+        return parsed
+
+    @field_validator("segmentRepetitionMaxAllowedConsecutiveRepeats")
+    @classmethod
+    def _validate_segment_repetition_max_allowed_repeats(cls, value: int) -> int:
+        parsed = int(value)
+        if parsed < 0:
+            raise ValueError(
+                "segmentRepetitionMaxAllowedConsecutiveRepeats must be non-negative"
+            )
+        return parsed
 
 
 class ThemeMode(str, Enum):


### PR DESCRIPTION
## Summary
- rename the repetition guardrail limit to `segmentRepetitionMaxAllowedConsecutiveRepeats`, raise its default, and accept the previous key via aliasing
- update the stream worker, tests, and docs to reflect the renamed configuration knob
- replace the repetition detector with a cached regex-based heuristic so strings with long consecutive repeats are flagged reliably
- add regression coverage that ensures highly repetitive transcripts such as the "Thank you, Adelaide" and "Yes, sir" loops are rejected

## Testing
- `PYTHONPATH=src poetry run pytest tests/test_stream_worker.py -k repetition_detection`

## Screenshot
![Segment repetition filter](browser:/invocations/sbmsgdoa/artifacts/artifacts/repetition-filter.png)

------
https://chatgpt.com/codex/tasks/task_e_68d5ef49ebcc832781203dc49d39049e