### PR TITLE
Adjust pager view colors in dark mode

### DIFF
--- a/frontend/src/components/StreamTranscriptionPanel.scss
+++ b/frontend/src/components/StreamTranscriptionPanel.scss
@@ -760,6 +760,60 @@
   gap: 0.35rem;
 }
 
+:root[data-bs-theme='dark'] {
+  .pager-transcript {
+    background-color: rgba(var(--transcript-segment-surface-rgb), 0.75);
+    border-color: rgba(var(--transcript-segment-surface-border-rgb), 0.85);
+    box-shadow: inset 0 0 0 1px rgba(var(--transcript-segment-surface-border-rgb), 0.4);
+  }
+
+  .pager-transcript__detail code {
+    background-color: rgba(var(--transcript-segment-time-rgb), 0.35);
+    color: rgb(var(--app-ink-rgb));
+  }
+
+  .pager-transcript__notes {
+    color: rgba(var(--app-ink-muted-rgb), 0.85);
+  }
+
+  .pager-transcript__fragments {
+    border-top-color: rgba(var(--transcript-segment-surface-border-rgb), 0.65);
+  }
+
+  .pager-transcript__fragments--open {
+    border-top-color: rgba(var(--transcript-segment-surface-border-rgb), 0.85);
+  }
+
+  .pager-transcript__fragments-toggle {
+    background-color: rgba(var(--transcript-segment-surface-rgb), 0.65);
+    border-color: rgba(var(--transcript-segment-surface-border-rgb), 0.75);
+    box-shadow: inset 0 1px 0 rgba(15, 23, 42, 0.35);
+    color: rgba(var(--app-ink-subtle-rgb), 0.9);
+  }
+
+  .pager-transcript__fragments-toggle:hover,
+  .pager-transcript__fragments-toggle:focus-visible {
+    border-color: rgba(var(--transcript-segment-surface-border-rgb), 0.95);
+    background-color: rgba(var(--transcript-segment-surface-rgb), 0.85);
+    color: rgb(var(--app-ink-rgb));
+  }
+
+  .pager-transcript__fragments-toggle--open {
+    background-color: rgba(var(--transcript-segment-surface-rgb), 0.95);
+    box-shadow: inset 0 1px 0 rgba(15, 23, 42, 0.25);
+  }
+
+  .pager-transcript__fragment-panel {
+    border-color: rgba(var(--transcript-segment-surface-border-rgb), 0.85);
+    background: linear-gradient(
+      135deg,
+      rgba(var(--transcript-segment-surface-rgb), 0.92),
+      rgba(var(--transcript-segment-surface-border-rgb), 0.6)
+    );
+    box-shadow: 0 8px 16px -12px rgba(2, 6, 23, 0.7);
+  }
+}
+
 .transcript-scroll-area {
   position: relative;
   display: flex;


### PR DESCRIPTION
## Summary
- tune pager transcript surfaces to use the transcript color palette in dark mode
- refresh pager fragment toggle and panel treatments to improve contrast with the dark theme

## Testing
- npm run lint

## Screenshots
![Dark mode pager view](browser:/invocations/gkqpvxdz/artifacts/artifacts/pager-dark-mode.png)

------
https://chatgpt.com/codex/tasks/task_e_68d6202ded6083278d7cf37370137811