### PR TITLE
Adjust mobile header button placement

### DIFF
--- a/frontend/src/components/AppHeader.react.tsx
+++ b/frontend/src/components/AppHeader.react.tsx
@@ -43,20 +43,6 @@ const AppHeader = ({
         <div className="app-header__container app-container">
           <div className="app-header__layout">
             <div className="app-header__branding">
-              {isMobileViewport ? (
-                <Button
-                  size="sm"
-                  use="light"
-                  appearance="outline"
-                  onClick={onOpenMobileSidebar}
-                  aria-controls="app-stream-sidebar"
-                  aria-expanded={isMobileSidebarOpen}
-                  aria-label="Open stream menu"
-                  startContent={<Menu size={18} />}
-                >
-                  <span>Streams</span>
-                </Button>
-              ) : null}
               <Activity className="text-warning" size={32} />
               <h1 className="h5 mb-0 text-white">WaveCap</h1>
             </div>
@@ -91,6 +77,21 @@ const AppHeader = ({
                     Transcript correction mode
                   </Flex>
                 </Flex>
+              ) : null}
+
+              {isMobileViewport ? (
+                <Button
+                  size="sm"
+                  use="light"
+                  appearance="outline"
+                  onClick={onOpenMobileSidebar}
+                  aria-controls="app-stream-sidebar"
+                  aria-expanded={isMobileSidebarOpen}
+                  aria-label="Open stream menu"
+                  startContent={<Menu size={18} />}
+                >
+                  <span>Streams</span>
+                </Button>
               ) : null}
 
               <Button


### PR DESCRIPTION
## Summary
- move the mobile-only Streams trigger into the header control group so it sits next to Settings

## Testing
- npm run lint

## Screenshots
![Mobile header with Streams next to Settings](browser:/invocations/ptuwcprm/artifacts/artifacts/mobile-header.png)

------
https://chatgpt.com/codex/tasks/task_e_68d62203f9c8832793bf0d36af392921