### PR TITLE
Disable preprompt in default config

### DIFF
--- a/backend/default-config.yaml
+++ b/backend/default-config.yaml
@@ -47,11 +47,11 @@ whisper:
   decodeTemperature: 0.0
   temperatureIncrementOnFallback: 0.2
   conditionOnPreviousText: false
-  initialPrompt: >-
-    This is part of an emergency radio conversation between firefighters and
-    other emergency services in South Australia. Priority callouts include
-    Adelaide, Adelaide fire out, Noarlunga, SITREP, SAPOL, and SES. Spell them
-    exactly when they are heard on air.
+  # initialPrompt: >-
+  #   This is part of an emergency radio conversation between firefighters and
+  #   other emergency services in South Australia. Priority callouts include
+  #   Adelaide, Adelaide fire out, Noarlunga, SITREP, SAPOL, and SES. Spell them
+  #   exactly when they are heard on air.
   # Front-end filtering keeps speech crisp and level.
   highpassCutoffHz: 250
   lowpassCutoffHz: 3800


### PR DESCRIPTION
## Summary
- comment out the Whisper initialPrompt block in the default configuration to disable the preprompt

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d623d725ec8327a8b01260284c5160