### PR TITLE
Fix upstream connectivity indicator ordering

### DIFF
--- a/frontend/src/components/StreamStatusIndicator.react.tsx
+++ b/frontend/src/components/StreamStatusIndicator.react.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import { Stream } from "@types";
+import type { Stream, TranscriptionResult } from "@types";
 
 type StreamStatusVariant = "active" | "queued" | "error" | "idle";
 
@@ -29,18 +29,22 @@ const toTitleCase = (label: string): string => {
     .join(" ");
 };
 
-const resolveUpstreamConnectivity = (stream: Stream): boolean | null => {
+export const resolveUpstreamConnectivity = (
+  stream: Stream,
+): boolean | null => {
   const candidate = (stream as { upstreamConnected?: unknown }).upstreamConnected;
   if (typeof candidate === "boolean") {
     return candidate;
   }
 
-  const transcriptions = Array.isArray(stream.transcriptions)
+  const transcriptions: TranscriptionResult[] = Array.isArray(
+    stream.transcriptions,
+  )
     ? stream.transcriptions
     : [];
 
-  for (let index = transcriptions.length - 1; index >= 0; index -= 1) {
-    const eventType = transcriptions[index]?.eventType;
+  for (const transcription of transcriptions) {
+    const eventType = transcription?.eventType;
     if (eventType === "upstream_disconnected") {
       return false;
     }
@@ -52,7 +56,9 @@ const resolveUpstreamConnectivity = (stream: Stream): boolean | null => {
   return null;
 };
 
-const resolveStreamStatus = (stream: Stream): StreamStatusResolution => {
+export const resolveStreamStatus = (
+  stream: Stream,
+): StreamStatusResolution => {
   if (!stream.enabled) {
     return { variant: "idle", label: "Transcription stopped" };
   }

--- a/frontend/src/components/StreamStatusIndicator.test.ts
+++ b/frontend/src/components/StreamStatusIndicator.test.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { Stream, TranscriptionResult } from "@types";
+import {
+  resolveStreamStatus,
+  resolveUpstreamConnectivity,
+} from "./StreamStatusIndicator.react.js";
+
+const baseTimestamp = Date.UTC(2024, 0, 1, 0, 0, 0);
+
+const createTranscription = (
+  id: string,
+  eventType?: TranscriptionResult["eventType"],
+  offsetMs = 0,
+): TranscriptionResult => ({
+  id,
+  streamId: "stream-1",
+  text: `${eventType ?? "transcription"}-${id}`,
+  timestamp: new Date(baseTimestamp + offsetMs).toISOString(),
+  eventType,
+  confidence: null,
+  duration: null,
+  segments: [],
+});
+
+const createStream = (
+  transcriptions: TranscriptionResult[],
+  overrides: Partial<Stream> = {},
+): Stream => ({
+  id: overrides.id ?? "stream-1",
+  name: overrides.name ?? "Example Stream",
+  url: overrides.url ?? "https://example.com/audio", // dummy URL
+  status: overrides.status ?? "transcribing",
+  enabled: overrides.enabled ?? true,
+  createdAt:
+    overrides.createdAt ?? new Date(baseTimestamp).toISOString(),
+  transcriptions,
+  language: overrides.language,
+  error: overrides.error,
+  source: overrides.source,
+  webhookToken: overrides.webhookToken,
+  ignoreFirstSeconds: overrides.ignoreFirstSeconds,
+  lastActivityAt: overrides.lastActivityAt,
+});
+
+test("resolveUpstreamConnectivity prioritises the most recent connectivity event", () => {
+  const stream = createStream([
+    createTranscription("reconnected", "upstream_reconnected", 2000),
+    createTranscription("disconnected", "upstream_disconnected", 1000),
+  ]);
+
+  assert.strictEqual(resolveUpstreamConnectivity(stream), true);
+});
+
+test("resolveUpstreamConnectivity reports disconnect when the latest event is a disconnect", () => {
+  const stream = createStream([
+    createTranscription("disconnected", "upstream_disconnected", 2000),
+    createTranscription("reconnected", "upstream_reconnected", 1000),
+  ]);
+
+  assert.strictEqual(resolveUpstreamConnectivity(stream), false);
+});
+
+test("resolveStreamStatus returns active when the upstream reconnects", () => {
+  const stream = createStream([
+    createTranscription("reconnected", "upstream_reconnected", 2000),
+    createTranscription("disconnected", "upstream_disconnected", 1000),
+  ]);
+
+  const status = resolveStreamStatus(stream);
+  assert.deepStrictEqual(status, {
+    variant: "active",
+    label: "Live transcription",
+  });
+});
+
+test("resolveStreamStatus surfaces upstream disconnects", () => {
+  const stream = createStream([
+    createTranscription("disconnected", "upstream_disconnected", 2000),
+    createTranscription("reconnected", "upstream_reconnected", 1000),
+  ]);
+
+  const status = resolveStreamStatus(stream);
+  assert.deepStrictEqual(status, {
+    variant: "error",
+    label: "Upstream disconnected",
+  });
+});


### PR DESCRIPTION
## Summary
- ensure the stream status indicator resolves upstream connectivity based on the newest transcription events
- expose the connectivity helpers for reuse and cover them with targeted unit tests

## Testing
- npm test

## Screenshots
![Stream status indicator screenshot](browser:/invocations/jtqjyunw/artifacts/artifacts/upstream-status.png)


------
https://chatgpt.com/codex/tasks/task_e_68d7ae7e76788327a5b598183d64dedd