### PR TITLE
Refine pager stream layout

### DIFF
--- a/frontend/src/components/StreamTranscriptionPanel.react.tsx
+++ b/frontend/src/components/StreamTranscriptionPanel.react.tsx
@@ -2276,13 +2276,13 @@ export const StreamTranscriptionPanel = ({
                 className="transcript-thread__pager-group"
                 key={`${group.id}-pager`}
               >
-                  {pagerMessages.map((message: CondensedPagerMessage, index) => {
-                    const shouldShowIncidentMap = Boolean(
-                      incidentLocationUrls && index === 0,
-                    );
-                    const fragmentElements = message.fragments.flatMap(
-                      (fragment) => elementMap.get(fragment.id) ?? [],
-                    );
+                {pagerMessages.map((message: CondensedPagerMessage, index) => {
+                  const shouldShowIncidentMap = Boolean(
+                    incidentLocationUrls && index === 0,
+                  );
+                  const fragmentElements = message.fragments.flatMap((fragment) =>
+                    elementMap.get(fragment.id) ?? [],
+                  );
                   const alertMap = new Map<
                     string,
                     ReturnType<typeof getNotifiableAlerts>[number]
@@ -2304,14 +2304,16 @@ export const StreamTranscriptionPanel = ({
                     </span>
                   ));
                   const fragmentChip =
-                    message.fragments.length > 1 ? (
-                      <span
-                        key={`${message.id}-fragments`}
-                        className="chip-button chip-button--surface pager-transcript__chip"
-                      >
-                        {message.fragments.length} fragments combined
-                      </span>
-                    ) : null;
+                    message.fragments.length > 1
+                      ? (
+                          <span
+                            key={`${message.id}-fragments`}
+                            className="chip-button chip-button--surface pager-transcript__chip"
+                          >
+                            {message.fragments.length} fragments combined
+                          </span>
+                        )
+                      : null;
 
                   const summaryText =
                     message.summary ||
@@ -2329,75 +2331,117 @@ export const StreamTranscriptionPanel = ({
                     (field) => field.key !== "raw_message",
                   );
 
+                  const mapSection =
+                    shouldShowIncidentMap && incidentLocationUrls
+                      ? (
+                          <div className="pager-transcript__map" key="map">
+                            <iframe
+                              title={`Incident map for ${incidentLocationQuery}`}
+                              src={incidentLocationUrls.embed}
+                              loading="lazy"
+                              referrerPolicy="no-referrer-when-downgrade"
+                              allowFullScreen
+                              className="pager-transcript__map-frame"
+                            />
+                            {incidentLocationUrls.link ? (
+                              <a
+                                href={incidentLocationUrls.link}
+                                target="_blank"
+                                rel="noreferrer noopener"
+                                className="pager-transcript__map-link"
+                              >
+                                <MapPin size={14} />
+                                Open in Google Maps
+                              </a>
+                            ) : null}
+                          </div>
+                        )
+                      : null;
+
+                  const notesSection =
+                    message.notes.length > 0
+                      ? (
+                          <div className="pager-transcript__notes-card" key="notes">
+                            <div className="pager-transcript__notes-title">Notes</div>
+                            <ul className="pager-transcript__notes">
+                              {message.notes.map((note, index) => (
+                                <li key={`${message.id}-note-${index}`}>{note}</li>
+                              ))}
+                            </ul>
+                          </div>
+                        )
+                      : null;
+
+                  const sidebarSections = [
+                    ...(mapSection ? [mapSection] : []),
+                    ...(notesSection ? [notesSection] : []),
+                  ];
+
+                  const chipElements = [
+                    ...(fragmentChip ? [fragmentChip] : []),
+                    ...alertChips,
+                  ];
+
                   return (
-                    <div key={message.id} className="pager-transcript">
-                      {summaryText ? (
-                        <div className="pager-transcript__summary">{summaryText}</div>
-                      ) : null}
-                      {fragmentChip || alertChips.length > 0 ? (
-                        <div className="pager-transcript__chips">
-                          {fragmentChip}
-                          {alertChips}
-                        </div>
-                      ) : null}
-                      {detailFields.length > 0 ? (
-                        <dl className="pager-transcript__details">
-                          {detailFields.map((field) => (
-                            <div
-                              key={`${message.id}-${field.key}`}
-                              className="pager-transcript__detail"
-                            >
-                              <dt>{field.label}</dt>
-                              <dd>
-                                {field.values.map((value, index) =>
-                                  field.format === "code" ? (
-                                    <code
-                                      key={`${message.id}-${field.key}-${index}`}
-                                    >
-                                      {value}
-                                    </code>
-                                  ) : (
-                                    <span
-                                      key={`${message.id}-${field.key}-${index}`}
-                                    >
-                                      {value}
-                                    </span>
-                                  ),
-                                )}
-                              </dd>
+                    <div
+                      key={message.id}
+                      className={`pager-transcript${
+                        sidebarSections.length > 0
+                          ? " pager-transcript--with-sidebar"
+                          : ""
+                      }`}
+                    >
+                      {(summaryText || chipElements.length > 0) && (
+                        <div className="pager-transcript__header">
+                          {summaryText ? (
+                            <div className="pager-transcript__summary">
+                              {summaryText}
                             </div>
-                          ))}
-                        </dl>
-                      ) : null}
-                      {shouldShowIncidentMap && incidentLocationUrls ? (
-                        <div className="pager-transcript__map">
-                          <iframe
-                            title={`Incident map for ${incidentLocationQuery}`}
-                            src={incidentLocationUrls.embed}
-                            loading="lazy"
-                            referrerPolicy="no-referrer-when-downgrade"
-                            allowFullScreen
-                            className="pager-transcript__map-frame"
-                          />
-                          {incidentLocationUrls.link ? (
-                            <a
-                              href={incidentLocationUrls.link}
-                              target="_blank"
-                              rel="noreferrer noopener"
-                              className="pager-transcript__map-link"
-                            >
-                              <MapPin size={14} />
-                              Open in Google Maps
-                            </a>
+                          ) : null}
+                          {chipElements.length > 0 ? (
+                            <div className="pager-transcript__chips">{chipElements}</div>
                           ) : null}
                         </div>
-                      ) : null}
-                      {message.notes.length > 0 ? (
-                        <ul className="pager-transcript__notes">
-                          {message.notes.map((note, index) => (
-                            <li key={`${message.id}-note-${index}`}>{note}</li>
-                          ))}
-                        </ul>
+                      )}
+                      {detailFields.length > 0 || sidebarSections.length > 0 ? (
+                        <div className="pager-transcript__body">
+                          {detailFields.length > 0 ? (
+                            <div className="pager-transcript__main">
+                              <dl className="pager-transcript__details">
+                                {detailFields.map((field) => (
+                                  <div
+                                    key={`${message.id}-${field.key}`}
+                                    className="pager-transcript__detail"
+                                  >
+                                    <dt>{field.label}</dt>
+                                    <dd>
+                                      {field.values.map((value, index) =>
+                                        field.format === "code" ? (
+                                          <code
+                                            key={`${message.id}-${field.key}-${index}`}
+                                          >
+                                            {value}
+                                          </code>
+                                        ) : (
+                                          <span
+                                            key={`${message.id}-${field.key}-${index}`}
+                                          >
+                                            {value}
+                                          </span>
+                                        ),
+                                      )}
+                                    </dd>
+                                  </div>
+                                ))}
+                              </dl>
+                            </div>
+                          ) : null}
+                          {sidebarSections.length > 0 ? (
+                            <aside className="pager-transcript__sidebar">
+                              {sidebarSections}
+                            </aside>
+                          ) : null}
+                        </div>
                       ) : null}
                       {fragmentElements.length > 0 ? (
                         <div
@@ -2451,6 +2495,10 @@ export const StreamTranscriptionPanel = ({
         ...pagerContent,
         ...baseItems,
       ];
+
+      const transcriptContentClassName = streamIsPager
+        ? "transcript-thread__content transcript-thread__content--pager"
+        : "transcript-thread__content";
 
       return (
         <article
@@ -2508,7 +2556,7 @@ export const StreamTranscriptionPanel = ({
                 ) : null}
               </div>
             ) : null}
-            <div className="transcript-thread__content">{groupContent}</div>
+            <div className={transcriptContentClassName}>{groupContent}</div>
             {audioElements}
           </div>
         </article>

--- a/frontend/src/components/StreamTranscriptionPanel.scss
+++ b/frontend/src/components/StreamTranscriptionPanel.scss
@@ -565,9 +565,20 @@
 .transcript-thread__content {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.25rem;
+  gap: 0.35rem;
   align-items: center;
   color: rgb(var(--app-ink-rgb));
+}
+
+.transcript-thread__content--pager {
+  flex-direction: column;
+  flex-wrap: nowrap;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.transcript-thread__content--pager > .transcript-thread__pager-group {
+  width: 100%;
 }
 
 .transcript-thread__incident-summary {
@@ -618,12 +629,19 @@
 .pager-transcript {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.75rem;
   padding: 0.75rem;
   border-radius: 0.75rem;
   border: 1px solid rgba(var(--bs-border-color-rgb, 222, 226, 230), 0.6);
   background-color: rgba(var(--app-surface-strong-rgb, 246, 249, 252), 0.6);
   box-shadow: inset 0 0 0 1px rgba(var(--app-surface-strong-rgb, 246, 249, 252), 0.4);
+}
+
+.pager-transcript__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: 0.5rem 0.75rem;
 }
 
 .pager-transcript__summary {
@@ -636,6 +654,7 @@
   display: flex;
   flex-wrap: wrap;
   gap: 0.35rem;
+  margin-left: auto;
 }
 
 .pager-transcript__chip {
@@ -644,10 +663,32 @@
   gap: 0.25rem;
 }
 
+.pager-transcript__body {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 0.75rem;
+}
+
+.pager-transcript--with-sidebar .pager-transcript__body {
+  gap: 0.75rem 1.25rem;
+}
+
+@media (min-width: 48rem) {
+  .pager-transcript--with-sidebar .pager-transcript__body {
+    grid-template-columns: minmax(0, 1.6fr) minmax(0, 1fr);
+  }
+}
+
+.pager-transcript__main {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
 .pager-transcript__details {
   display: grid;
-  gap: 0.4rem 0.75rem;
-  grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+  gap: 0.5rem 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(11rem, 1fr));
   font-size: 0.85rem;
 }
 
@@ -681,9 +722,32 @@
   background-color: rgba(var(--app-ink-muted-rgb), 0.08);
 }
 
+.pager-transcript__sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.pager-transcript__notes-card {
+  padding: 0.6rem 0.75rem;
+  border-radius: 0.65rem;
+  border: 1px solid rgba(var(--bs-border-color-rgb, 222, 226, 230), 0.6);
+  background-color: rgba(var(--app-surface-rgb), 0.55);
+  box-shadow: inset 0 0 0 1px rgba(var(--app-surface-strong-rgb, 246, 249, 252), 0.35);
+}
+
+.pager-transcript__notes-title {
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgb(var(--app-ink-subtle-rgb));
+  margin-bottom: 0.35rem;
+}
+
 .pager-transcript__notes {
   margin: 0;
-  padding-left: 1rem;
+  padding-left: 1.1rem;
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
@@ -803,6 +867,12 @@
   .pager-transcript__detail code {
     background-color: rgba(var(--transcript-segment-time-rgb), 0.35);
     color: rgb(var(--app-ink-rgb));
+  }
+
+  .pager-transcript__notes-card {
+    background-color: rgba(var(--transcript-segment-surface-rgb), 0.6);
+    border-color: rgba(var(--transcript-segment-surface-border-rgb), 0.75);
+    box-shadow: inset 0 0 0 1px rgba(var(--transcript-segment-surface-border-rgb), 0.35);
   }
 
   .pager-transcript__notes {


### PR DESCRIPTION
## Summary
- restructure pager transcript rendering to include a structured header, detail grid, and optional sidebar content for maps and notes
- stack pager content within transcript groups to provide a condensed, full-width presentation for pager streams
- refresh pager styling with responsive grid layout, sidebar cards, and updated spacing for badges and notes

## Testing
- npm run lint

## Screenshots
![Pager stream layout](browser:/invocations/xvwfazeo/artifacts/artifacts/pager-condensed.png)


------
https://chatgpt.com/codex/tasks/task_e_68d7aebdbcf083278a1e1b2731e42ad9