### PR TITLE
Remove stream management actions from the UI

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -83,16 +83,16 @@ transcribing multiple radio or pager feeds in real time.
 - Start the backend with curated demo data using `--screenshot-fixtures` (alias `--fixture-set screenshot`) on `python -m wavecap_backend`, `start-app.sh`, or `start-app.ps1`. The flag resets state and loads representative streams, transcripts, reviews, alerts, and audio placeholders for documentation captures.
 
 ## Operator Interface Map
-- **Conversation Workspace**: Messenger-style layout with a sidebar that sorts streams by activity and shows unread indicators. When no streams exist, the pane prompts the operator to add one.
+- **Conversation Workspace**: Messenger-style layout with a sidebar that sorts streams by activity and shows unread indicators. When no streams exist, the pane reminds operators to define them in the configuration files.
 - **Metrics Cards**: Show active stream counts, transcript totals, average confidence, and processed audio time.
-- **Stream Sidebar**: Hosts the add-stream form plus Start and Stop controls inside each conversation header, with Reset and Remove tucked behind a "More actions" overflow button. Status badges show transcribing, stopped, or error states at a glance.
+- **Stream Sidebar**: Lists configured streams, highlights status at a glance, and surfaces Start/Stop controls inside each conversation header with Reset tucked behind a "More actions" overflow button. Streams themselves are defined in YAML configuration files.
 - **Transcript Panel**: Fills the conversation pane with grouped bursts, timestamps (in the viewer's timezone), confidence colours, and inline playback. Segments keep their width while playing so text does not shift. Conversations stay anchored to the latest entries, auto-scroll at the live edge, and reveal a "Go to latest" pill when the user scrolls up.
 - **Global Controls**: Surface red error toasts and green confirmations after actions.
 - **Transcript Correction Toggle**: Header checkbox (editors only) that hides or shows review badges, editing tools, and exports.
 - **Reviewed Export Controls**: Header controls that select review states before downloading a ZIP with JSONL transcripts and audio clips.
 
 ## Frontend Component Roles
-- **StreamDirectoryPanel**: Wraps the stream list, status badges, and controls for starting, stopping, resetting, removing, or adding streams.
+- **StreamDirectoryPanel**: Wraps the stream list, status badges, and controls for starting, stopping, or resetting streams.
 - **TranscriptionMetricsPanel**: Summarises live activity with aggregate transcription counts, confidence, and duration.
 - **StreamTranscriptionPanel**: Shows grouped transcript bursts, history and search tools, playback controls, and an optional live audio player.
 - **TranscriptionSummaryCard**: Presents a single transcription with timestamps, durations, and confidence indicators.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -42,13 +42,13 @@ server:
 
 ## Pager feeds
 
-Some agencies publish pager updates without a backing audio stream. Add these sources as *pager* streams via the sidebar form or the `/api/streams` endpoint by sending `{ "source": "pager" }`. The backend returns a token-protected webhook at `/api/pager-feeds/<streamId>?token=<token>`; POST JSON with at least a `message` field (plus optional `sender`, `details`, or `priority`) and the text appears instantly in the UI alongside audio transcripts. Tokens persist in `state/runtime.sqlite`; delete and recreate the stream if you ever need to rotate the token.
+Some agencies publish pager updates without a backing audio stream. Add these sources as *pager* streams in your configuration files or via the `/api/streams` endpoint by sending `{ "source": "pager" }`. The backend returns a token-protected webhook at `/api/pager-feeds/<streamId>?token=<token>`; POST JSON with at least a `message` field (plus optional `sender`, `details`, or `priority`) and the text appears instantly in the UI alongside audio transcripts. Tokens persist in `state/runtime.sqlite`; delete and recreate the stream if you ever need to rotate the token.
 
 When the CAD system emits a known structured payload, add `&format=<name>` to the webhook URL so the backend can normalise it automatically. For example, South Australia CFS Flex dispatch posts can be delivered with `&format=cfs-flex`, allowing the backend to extract the incident number, address, alarm level, talkgroup, and supporting details without requiring a separate middleware script.
 
 ## Audio stream pre-roll trimming
 
-Dispatch providers such as Broadcastify play an advertisement or dial tone before the feed goes live. The backend automatically skips the first 30 seconds for Broadcastify feeds when no override is provided so operators are never greeted by the ad. Set `ignoreFirstSeconds` on any audio stream to customise the pre-roll trimming window. The value can be configured in `defaultStreams`, via `state/config.yaml`, or when adding a stream through the UI. A value of `30` skips the first half-minute, which matches the Broadcastify ad length.
+Dispatch providers such as Broadcastify play an advertisement or dial tone before the feed goes live. The backend automatically skips the first 30 seconds for Broadcastify feeds when no override is provided so operators are never greeted by the ad. Set `ignoreFirstSeconds` on any audio stream to customise the pre-roll trimming window. Configure the value in `defaultStreams` or via `state/config.yaml`. A value of `30` skips the first half-minute, which matches the Broadcastify ad length.
 
 ```yaml
 defaultStreams:

--- a/frontend/src/components/StreamDirectoryPanel.react.tsx
+++ b/frontend/src/components/StreamDirectoryPanel.react.tsx
@@ -1,13 +1,4 @@
-import { FormEvent, useState } from "react";
-import {
-  Plus,
-  Trash2,
-  Play,
-  Square,
-  Radio,
-  AlertCircle,
-  Clock,
-} from "lucide-react";
+import { Play, Square, Radio, AlertCircle, Clock } from "lucide-react";
 import { Stream, type StreamCommandState } from "@types";
 import Spinner from "./primitives/Spinner.react";
 import Button from "./primitives/Button.react";
@@ -16,8 +7,6 @@ import "./StreamDirectoryPanel.scss";
 
 interface StreamDirectoryPanelProps {
   streams: Stream[];
-  onAddStream: (url: string, name?: string, language?: string) => void;
-  onRemoveStream: (streamId: string) => void;
   onStartTranscription: (streamId: string) => void;
   onStopTranscription: (streamId: string) => void;
   loading: boolean;
@@ -54,37 +43,11 @@ const getStatusBadgeClass = (variant: StreamStatusVariant) => {
 
 export const StreamDirectoryPanel = ({
   streams,
-  onAddStream,
-  onRemoveStream,
   onStartTranscription,
   onStopTranscription,
   loading,
   pendingCommands = {},
 }: StreamDirectoryPanelProps) => {
-  const [showAddForm, setShowAddForm] = useState(false);
-  const [newStreamUrl, setNewStreamUrl] = useState("");
-  const [newStreamName, setNewStreamName] = useState("");
-  const [newStreamLanguage, setNewStreamLanguage] = useState("en");
-
-  const handleAddStream = async (event: FormEvent) => {
-    event.preventDefault();
-    if (!newStreamUrl.trim()) {
-      return;
-    }
-
-    try {
-      await onAddStream(
-        newStreamUrl.trim(),
-        newStreamName.trim() || undefined,
-        newStreamLanguage,
-      );
-      setNewStreamUrl("");
-      setNewStreamName("");
-      setShowAddForm(false);
-    } catch (error) {
-      console.error("Failed to add stream:", error);
-    }
-  };
 
   const renderStatusIcon = (variant: StreamStatusVariant) => {
     switch (variant) {
@@ -109,100 +72,9 @@ export const StreamDirectoryPanel = ({
         gap={3}
       >
         <h2 className="h5 mb-0">Stream management</h2>
-        <Button
-          type="button"
-          size="sm"
-          use="primary"
-          onClick={() => setShowAddForm((current) => !current)}
-          startContent={<Plus size={16} />}
-        >
-          {showAddForm ? "Hide form" : "Add stream"}
-        </Button>
       </Flex>
 
       <div className="card-body">
-        {showAddForm && (
-          <form
-            onSubmit={handleAddStream}
-            className="bg-body-tertiary border rounded-3 p-3 p-md-4 mb-4"
-          >
-            <div className="row g-3">
-              <div className="col-12 col-md-6">
-                <label
-                  htmlFor="new-stream-url"
-                  className="form-label text-uppercase text-body-secondary fw-semibold small"
-                >
-                  Stream URL
-                </label>
-                <input
-                  id="new-stream-url"
-                  type="url"
-                  value={newStreamUrl}
-                  onChange={(event) => setNewStreamUrl(event.target.value)}
-                  placeholder="https://example.com/stream.mp3"
-                  className="form-control"
-                  required
-                />
-              </div>
-              <div className="col-12 col-md-6">
-                <label
-                  htmlFor="new-stream-name"
-                  className="form-label text-uppercase text-body-secondary fw-semibold small"
-                >
-                  Stream name (optional)
-                </label>
-                <input
-                  id="new-stream-name"
-                  type="text"
-                  value={newStreamName}
-                  onChange={(event) => setNewStreamName(event.target.value)}
-                  placeholder="My stream"
-                  className="form-control"
-                />
-              </div>
-              <div className="col-12 col-md-6 col-lg-4">
-                <label
-                  htmlFor="new-stream-language"
-                  className="form-label text-uppercase text-body-secondary fw-semibold small"
-                >
-                  Language
-                </label>
-                <select
-                  id="new-stream-language"
-                  value={newStreamLanguage}
-                  onChange={(event) => setNewStreamLanguage(event.target.value)}
-                  className="form-select"
-                >
-                  <option value="en">English</option>
-                  <option value="es">Spanish</option>
-                  <option value="fr">French</option>
-                  <option value="de">German</option>
-                  <option value="it">Italian</option>
-                  <option value="pt">Portuguese</option>
-                  <option value="ru">Russian</option>
-                  <option value="ja">Japanese</option>
-                  <option value="ko">Korean</option>
-                  <option value="zh">Chinese</option>
-                  <option value="auto">Auto-detect</option>
-                </select>
-              </div>
-            </div>
-            <Flex wrap="wrap" gap={2} className="mt-3">
-              <Button type="submit" size="sm" use="primary">
-                Add stream
-              </Button>
-              <Button
-                type="button"
-                size="sm"
-                use="secondary"
-                onClick={() => setShowAddForm(false)}
-              >
-                Cancel
-              </Button>
-            </Flex>
-          </form>
-        )}
-
         {loading ? (
           <div className="text-center py-5 text-body-secondary">
             <Spinner label="Loading streams" />
@@ -213,7 +85,7 @@ export const StreamDirectoryPanel = ({
             <Radio className="text-primary mb-3" size={48} />
             <p className="fs-5 mb-1">No streams configured</p>
             <p className="mb-0">
-              Add a stream to get started with transcription.
+              Define streams in your configuration files to enable transcription.
             </p>
           </div>
         ) : (
@@ -223,11 +95,10 @@ export const StreamDirectoryPanel = ({
               const pendingAction = pendingCommands[stream.id];
               const isStopping = pendingAction === "stopping";
               const isStarting = pendingAction === "starting";
-              const isRemoving = pendingAction === "removing";
               const isResetting = pendingAction === "resetting";
               const isUpdating = pendingAction === "updating";
               const disableAll =
-                isStopping || isStarting || isRemoving || isResetting || isUpdating;
+                isStopping || isStarting || isResetting || isUpdating;
               return (
                 <Flex
                   key={stream.id}
@@ -341,27 +212,6 @@ export const StreamDirectoryPanel = ({
                         </Button>
                       );
                     })()}
-
-                    <Button
-                      type="button"
-                      size="sm"
-                      use="secondary"
-                      onClick={() => onRemoveStream(stream.id)}
-                      disabled={disableAll}
-                      startContent={
-                        isRemoving ? (
-                          <Spinner
-                            size="sm"
-                            variant="light"
-                            label="Removing stream"
-                          />
-                        ) : (
-                          <Trash2 size={14} />
-                        )
-                      }
-                    >
-                      <span>{isRemoving ? "Removing…" : "Remove"}</span>
-                    </Button>
                   </Flex>
                 </Flex>
               );

--- a/frontend/src/components/StreamSidebar.react.tsx
+++ b/frontend/src/components/StreamSidebar.react.tsx
@@ -1,10 +1,10 @@
-import { ChangeEvent, FormEvent, ReactNode } from "react";
-import { LogIn, Plus, Radio, X } from "lucide-react";
-import { Stream, StreamSource } from "@types";
-import Spinner from "./primitives/Spinner.react";
+import { ReactNode } from "react";
+import { LogIn, Radio, X } from "lucide-react";
+import { Stream } from "@types";
 import Button from "./primitives/Button.react";
 import Badge from "./primitives/Badge.react";
 import Flex from "./primitives/Flex.react";
+import Spinner from "./primitives/Spinner.react";
 import StreamStatusIndicator from "./StreamStatusIndicator.react";
 import "./StreamSidebar.scss";
 
@@ -22,23 +22,6 @@ export interface StreamSidebarItem {
 interface StreamSidebarProps {
   isReadOnly: boolean;
   onRequestLogin: () => void;
-  showAddStreamForm: boolean;
-  onToggleAddStreamForm: () => void;
-  onCloseAddStreamForm: () => void;
-  onClearAddStreamError: () => void;
-  addStreamError: string | null;
-  addingStream: boolean;
-  newStreamSource: StreamSource;
-  onChangeStreamSource: (value: StreamSource) => void;
-  newStreamUrl: string;
-  onChangeStreamUrl: (value: string) => void;
-  newStreamName: string;
-  onChangeStreamName: (value: string) => void;
-  newStreamLanguage: string;
-  onChangeStreamLanguage: (value: string) => void;
-  newStreamIgnoreSeconds: string;
-  onChangeStreamIgnoreSeconds: (value: string) => void;
-  onSubmitAddStream: (event: FormEvent<HTMLFormElement>) => void;
   items: StreamSidebarItem[];
   loading: boolean;
   onSelectStream: (streamId: string) => void;
@@ -47,28 +30,9 @@ interface StreamSidebarProps {
   onCloseMobileSidebar: () => void;
 }
 
-const ADD_STREAM_FORM_ID = "stream-sidebar-add-form";
-
 const StreamSidebar = ({
   isReadOnly,
   onRequestLogin,
-  showAddStreamForm,
-  onToggleAddStreamForm,
-  onCloseAddStreamForm,
-  onClearAddStreamError,
-  addStreamError,
-  addingStream,
-  newStreamSource,
-  onChangeStreamSource,
-  newStreamUrl,
-  onChangeStreamUrl,
-  newStreamName,
-  onChangeStreamName,
-  newStreamLanguage,
-  onChangeStreamLanguage,
-  newStreamIgnoreSeconds,
-  onChangeStreamIgnoreSeconds,
-  onSubmitAddStream,
   items,
   loading,
   onSelectStream,
@@ -76,18 +40,6 @@ const StreamSidebar = ({
   isMobileSidebarOpen,
   onCloseMobileSidebar,
 }: StreamSidebarProps) => {
-  const handleToggleAddForm = () => {
-    if (showAddStreamForm) {
-      onClearAddStreamError();
-    }
-    onToggleAddStreamForm();
-  };
-
-  const handleCloseAddForm = () => {
-    onClearAddStreamError();
-    onCloseAddStreamForm();
-  };
-
   const renderEmptyState = () => {
     if (loading) {
       return null;
@@ -100,8 +52,8 @@ const StreamSidebar = ({
           <p className="fw-semibold mb-1">No streams yet</p>
           <p className="mb-2 small">
             {isReadOnly
-              ? "Sign in to add streams and control live transcription."
-              : "Add a stream to start monitoring conversations."}
+              ? "Sign in to control live transcription for configured streams."
+              : "Update your configuration files to add new streams."}
           </p>
           {isReadOnly ? (
             <Button
@@ -141,18 +93,6 @@ const StreamSidebar = ({
             </p>
           </div>
           <Flex align="center" gap={2}>
-            {!isReadOnly ? (
-              <Button
-                size="sm"
-                use="primary"
-                onClick={handleToggleAddForm}
-                aria-expanded={showAddStreamForm}
-                aria-controls={ADD_STREAM_FORM_ID}
-                startContent={<Plus size={14} />}
-              >
-                {showAddStreamForm ? "Hide form" : "Add stream"}
-              </Button>
-            ) : null}
             <Button
               size="sm"
               use="secondary"
@@ -165,171 +105,6 @@ const StreamSidebar = ({
             </Button>
           </Flex>
         </Flex>
-
-        {!isReadOnly && showAddStreamForm ? (
-          <form
-            className="stream-sidebar__form"
-            onSubmit={onSubmitAddStream}
-            id={ADD_STREAM_FORM_ID}
-          >
-              <div className="mb-3">
-                <label
-                  htmlFor="sidebar-stream-source"
-                  className="form-label text-uppercase small fw-semibold text-body-secondary"
-                >
-                  Stream type
-                </label>
-                <select
-                  id="sidebar-stream-source"
-                  className="form-select form-select-sm"
-                  value={newStreamSource}
-                  onChange={(event: ChangeEvent<HTMLSelectElement>) => {
-                    onChangeStreamSource(event.target.value as StreamSource);
-                  }}
-                >
-                  <option value="audio">Audio stream</option>
-                  <option value="pager">Pager feed</option>
-                </select>
-                {newStreamSource === "pager" ? (
-                  <p className="form-text small mb-0">
-                    Pager feeds accept webhook posts and generate their own
-                    authentication token.
-                  </p>
-                ) : null}
-              </div>
-              {newStreamSource === "audio" ? (
-                <div className="mb-3">
-                  <label
-                    htmlFor="sidebar-stream-url"
-                    className="form-label text-uppercase small fw-semibold text-body-secondary"
-                  >
-                    Stream URL
-                  </label>
-                  <input
-                    id="sidebar-stream-url"
-                    type="url"
-                    required
-                    className="form-control form-control-sm"
-                    placeholder="https://example.com/stream.mp3"
-                    value={newStreamUrl}
-                    onChange={(event: ChangeEvent<HTMLInputElement>) =>
-                      onChangeStreamUrl(event.target.value)
-                    }
-                  />
-                </div>
-              ) : null}
-              <div className="mb-3">
-                <label
-                  htmlFor="sidebar-stream-name"
-                  className="form-label text-uppercase small fw-semibold text-body-secondary"
-                >
-                  Display name (optional)
-                </label>
-                <input
-                  id="sidebar-stream-name"
-                  type="text"
-                  className="form-control form-control-sm"
-                  placeholder="Scanner feed"
-                  value={newStreamName}
-                  onChange={(event: ChangeEvent<HTMLInputElement>) =>
-                    onChangeStreamName(event.target.value)
-                  }
-                />
-              </div>
-              {newStreamSource === "audio" ? (
-                <div className="mb-3">
-                  <label
-                    htmlFor="sidebar-stream-language"
-                    className="form-label text-uppercase small fw-semibold text-body-secondary"
-                  >
-                    Language
-                  </label>
-                  <select
-                    id="sidebar-stream-language"
-                    className="form-select form-select-sm"
-                    value={newStreamLanguage}
-                    onChange={(event: ChangeEvent<HTMLSelectElement>) =>
-                      onChangeStreamLanguage(event.target.value)
-                    }
-                  >
-                    <option value="en">English</option>
-                    <option value="es">Spanish</option>
-                    <option value="fr">French</option>
-                    <option value="de">German</option>
-                    <option value="it">Italian</option>
-                    <option value="pt">Portuguese</option>
-                    <option value="ru">Russian</option>
-                    <option value="ja">Japanese</option>
-                    <option value="ko">Korean</option>
-                    <option value="zh">Chinese</option>
-                    <option value="auto">Auto-detect</option>
-                  </select>
-                </div>
-              ) : null}
-              {newStreamSource === "audio" ? (
-                <div className="mb-3">
-                  <label
-                    htmlFor="sidebar-stream-ignore"
-                    className="form-label text-uppercase small fw-semibold text-body-secondary"
-                  >
-                    Skip first seconds
-                  </label>
-                  <input
-                    id="sidebar-stream-ignore"
-                    type="number"
-                    min="0"
-                    step="0.1"
-                    className="form-control form-control-sm"
-                    placeholder="0"
-                    value={newStreamIgnoreSeconds}
-                    onChange={(event: ChangeEvent<HTMLInputElement>) =>
-                      onChangeStreamIgnoreSeconds(event.target.value)
-                    }
-                  />
-                  <div className="form-text small mb-0">
-                    Omit the ad or dial tone at the start of the stream before
-                    recording.
-                  </div>
-                </div>
-              ) : null}
-              {addStreamError ? (
-                <div
-                  className="alert alert-warning py-2 px-3 small"
-                  role="alert"
-                >
-                  {addStreamError}
-                </div>
-              ) : null}
-              <Flex wrap="wrap" gap={2}>
-                <Button
-                  type="submit"
-                  size="sm"
-                  use="primary"
-                  disabled={addingStream}
-                  startContent={
-                    addingStream ? (
-                      <Spinner
-                        size="sm"
-                        variant="light"
-                        label="Adding stream"
-                      />
-                    ) : undefined
-                  }
-                >
-                  <span>{addingStream ? "Adding…" : "Add stream"}</span>
-                </Button>
-                <Button
-                  type="button"
-                  size="sm"
-                  use="secondary"
-                  onClick={handleCloseAddForm}
-                  disabled={addingStream}
-                >
-                  Cancel
-                </Button>
-              </Flex>
-          </form>
-        ) : null}
 
         <div className="stream-sidebar__list">
           {loading ? (

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -8,7 +8,6 @@ export type StreamCommandState =
   | "starting"
   | "stopping"
   | "resetting"
-  | "removing"
   | "updating";
 
 export type AccessRole = "read_only" | "editor";


### PR DESCRIPTION
## Summary
- remove the add/remove stream forms and buttons from the sidebar, directory panel, and conversation actions so streams are managed via config
- clean up command state handling and docs/spec references to reflect configuration-driven stream management

## Testing
- npm run lint

## Screenshots
![Stream sidebar without add/remove controls](browser:/invocations/aqaksctm/artifacts/artifacts/stream-sidebar.png)

------
https://chatgpt.com/codex/tasks/task_e_68d7afabd1988327a0af5d39d90c7efb