### PR TITLE
Improve proxy-aware client attribution

### DIFF
--- a/backend/src/wavecap_backend/request_utils.py
+++ b/backend/src/wavecap_backend/request_utils.py
@@ -1,0 +1,113 @@
+"""Request helper utilities."""
+
+from __future__ import annotations
+
+from typing import Mapping, Optional, Protocol, Sequence, Tuple, Union
+
+
+class SupportsClientAddress(Protocol):
+    host: str
+    port: Union[int, str]
+
+
+ClientAddress = Union[SupportsClientAddress, Tuple[str, int], Tuple[str, int, int]]
+
+
+def _normalise_headers(headers: Mapping[str, str]) -> dict[str, str]:
+    """Return a lower-cased copy of HTTP headers."""
+
+    normalised: dict[str, str] = {}
+    for key, value in headers.items():
+        if not isinstance(key, str) or not isinstance(value, str):
+            continue
+        normalised[key.lower()] = value
+    return normalised
+
+
+def _split_csv(value: str) -> Sequence[str]:
+    return [part.strip() for part in value.split(",") if part.strip()]
+
+
+def _extract_client_components(client: Optional[ClientAddress]) -> tuple[Optional[str], Optional[str]]:
+    if client is None:
+        return None, None
+
+    host: Optional[str] = None
+    port: Optional[str] = None
+
+    if hasattr(client, "host"):
+        host_value = getattr(client, "host")
+        if isinstance(host_value, str) and host_value:
+            host = host_value
+    if hasattr(client, "port"):
+        port_value = getattr(client, "port")
+        if isinstance(port_value, int):
+            port = str(port_value)
+        elif isinstance(port_value, str) and port_value:
+            port = port_value
+
+    if isinstance(client, tuple):
+        if host is None and len(client) >= 1 and isinstance(client[0], str):
+            host = client[0]
+        if port is None and len(client) >= 2:
+            port_candidate = client[1]
+            if isinstance(port_candidate, int):
+                port = str(port_candidate)
+            elif isinstance(port_candidate, str) and port_candidate:
+                port = port_candidate
+
+    return host, port
+
+
+def _pick_first_header(normalised: Mapping[str, str], names: Sequence[str]) -> Optional[str]:
+    for name in names:
+        value = normalised.get(name)
+        if value:
+            stripped = value.strip()
+            if stripped:
+                return stripped
+    return None
+
+
+def describe_remote_client(headers: Mapping[str, str], client: Optional[ClientAddress]) -> str:
+    """Return a descriptive label for the remote client.
+
+    The function prioritises proxy headers such as ``CF-Connecting-IP`` and
+    ``X-Forwarded-For`` while falling back to the transport address reported by
+    ASGI when no proxy metadata is provided.
+    """
+
+    normalised = _normalise_headers(headers)
+
+    host_headers = (
+        "cf-connecting-ip",
+        "true-client-ip",
+        "x-real-ip",
+    )
+    host = _pick_first_header(normalised, host_headers)
+    if not host:
+        forwarded_for = normalised.get("x-forwarded-for")
+        if forwarded_for:
+            forwarded_chain = _split_csv(forwarded_for)
+            if forwarded_chain:
+                host = forwarded_chain[0]
+
+    fallback_host, fallback_port = _extract_client_components(client)
+    if not host:
+        host = fallback_host
+
+    port_headers = ("cf-connecting-port", "x-forwarded-port")
+    port = _pick_first_header(normalised, port_headers)
+    if not port:
+        port = fallback_port
+
+    if host and port:
+        return f"{host}:{port}"
+    if host:
+        return host
+    if port:
+        return f"unknown:{port}"
+    return "unknown-client"
+
+
+__all__ = ["describe_remote_client"]

--- a/backend/src/wavecap_backend/server.py
+++ b/backend/src/wavecap_backend/server.py
@@ -61,6 +61,7 @@ from .models import (
 )
 from .pager_formats import parse_pager_webhook_payload
 from .state_paths import PROJECT_ROOT, RECORDINGS_DIR, resolve_state_path
+from .request_utils import describe_remote_client
 from .stream_manager import StreamManager
 from .whisper_transcriber import (
     AbstractTranscriber,
@@ -124,8 +125,7 @@ async def stream_events(
     token: Optional[str],
     initial_role: AccessRole,
 ) -> None:
-    client = websocket.client
-    client_label = f"{client.host}:{client.port}" if client else "unknown-client"
+    client_label = describe_remote_client(websocket.headers, websocket.client)
     current_role = initial_role
     LOGGER.info(
         "WebSocket connection established from %s with role %s",

--- a/backend/tests/test_request_utils.py
+++ b/backend/tests/test_request_utils.py
@@ -1,0 +1,51 @@
+from typing import NamedTuple
+
+from wavecap_backend.request_utils import describe_remote_client
+
+
+class DummyAddress(NamedTuple):
+    host: str
+    port: int
+
+
+def test_prefers_proxy_headers_over_client_address() -> None:
+    headers = {
+        "CF-Connecting-IP": "203.0.113.10",
+        "CF-Connecting-Port": "8443",
+        "X-Forwarded-For": "198.51.100.5, 192.0.2.4",
+    }
+    client = DummyAddress(host="10.0.0.2", port=1234)
+
+    label = describe_remote_client(headers, client)
+
+    assert label == "203.0.113.10:8443"
+
+
+def test_falls_back_to_first_forwarded_for() -> None:
+    headers = {"X-Forwarded-For": "198.51.100.5, 192.0.2.4"}
+    client = DummyAddress(host="10.0.0.2", port=1234)
+
+    label = describe_remote_client(headers, client)
+
+    assert label == "198.51.100.5:1234"
+
+
+def test_uses_transport_address_when_no_headers_present() -> None:
+    headers: dict[str, str] = {}
+    client = DummyAddress(host="10.0.0.2", port=1234)
+
+    label = describe_remote_client(headers, client)
+
+    assert label == "10.0.0.2:1234"
+
+
+def test_handles_missing_port_information() -> None:
+    headers = {"X-Real-IP": "198.51.100.5"}
+
+    label = describe_remote_client(headers, None)
+
+    assert label == "198.51.100.5"
+
+
+def test_returns_unknown_when_details_missing() -> None:
+    assert describe_remote_client({}, None) == "unknown-client"


### PR DESCRIPTION
## Summary
- add a proxy-aware `describe_remote_client` helper for resolving real client addresses
- apply the helper to websocket logging so proxied deployments retain meaningful labels
- cover the new logic with request utility unit tests

## Testing
- `PYTHONPATH=src pytest tests/test_request_utils.py`

## Screenshots
![WaveCap dashboard](browser:/invocations/uvuxoeto/artifacts/artifacts/wavecap-dashboard.png)


------
https://chatgpt.com/codex/tasks/task_e_68d7b27ac774832783fffaf06324762d